### PR TITLE
ローカルのGraphQLに対してyarn generateを行うことができる

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,6 @@
 
 1. `git clone https://github.com/Snak0201/fpb-wwwview.git`でクローンを行います
 2. `docker compose build`でビルドします
-3. `docker compose up -d`で起動します
-4. `localhost:8001`で画面が開きます
+3. `fpb-wwwsite`を起動します
+4. `docker compose up -d`で起動します
+5. `localhost:8001`で画面が開きます

--- a/codegen.yml
+++ b/codegen.yml
@@ -1,5 +1,5 @@
 overwrite: true
-schema: https://hoshinonaka.net/graphql
+schema: http://wwwsite-app:3000/graphql
 documents: src/**/*.gql
 generates:
   src/graphql/generated.ts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,15 @@ services:
       - .:/app
       - node_modules:/var/www/app/node_modules
     command: sh -c "yarn && npm run dev -- -p 3001"
-  
+    networks:
+      - wwwview
+      - wwwsite_view
+
 volumes:
   node_modules:
-  
+
+networks:
+  wwwview:
+    name: wwwview
+  wwwsite_view:
+    external: true

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -18,6 +18,47 @@ export type Scalars = {
   ISO8601DateTime: { input: any; output: any; }
 };
 
+/** published article on Hoshinonaka Government */
+export type Article = {
+  __typename?: 'Article';
+  /** jurisdiction bureau */
+  bureaus?: Maybe<Array<Bureau>>;
+  /** markdown content */
+  content?: Maybe<Scalars['String']['output']>;
+  /** created at */
+  createdAt: Scalars['ISO8601DateTime']['output'];
+  /** id */
+  id: Scalars['ID']['output'];
+  /** category number */
+  number: Scalars['Int']['output'];
+  /** published at */
+  publishedAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
+  /** title */
+  title: Scalars['String']['output'];
+  /** updated at */
+  updatedAt: Scalars['ISO8601DateTime']['output'];
+};
+
+/** The connection type for Article. */
+export type ArticleConnection = {
+  __typename?: 'ArticleConnection';
+  /** A list of edges. */
+  edges?: Maybe<Array<Maybe<ArticleEdge>>>;
+  /** A list of nodes. */
+  nodes?: Maybe<Array<Maybe<Article>>>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+};
+
+/** An edge in a connection. */
+export type ArticleEdge = {
+  __typename?: 'ArticleEdge';
+  /** A cursor for use in pagination. */
+  cursor: Scalars['String']['output'];
+  /** The item at the end of the edge. */
+  node?: Maybe<Article>;
+};
+
 /** bureau model */
 export type Bureau = {
   __typename?: 'Bureau';
@@ -37,13 +78,37 @@ export type Bureau = {
   updatedAt: Scalars['ISO8601DateTime']['output'];
 };
 
+/** Information about pagination in a connection. */
+export type PageInfo = {
+  __typename?: 'PageInfo';
+  /** When paginating forwards, the cursor to continue. */
+  endCursor?: Maybe<Scalars['String']['output']>;
+  /** When paginating forwards, are there more items? */
+  hasNextPage: Scalars['Boolean']['output'];
+  /** When paginating backwards, are there more items? */
+  hasPreviousPage: Scalars['Boolean']['output'];
+  /** When paginating backwards, the cursor to continue. */
+  startCursor?: Maybe<Scalars['String']['output']>;
+};
+
 /** queries */
 export type Query = {
   __typename?: 'Query';
-  /** get single bureau with slug */
+  /** all published articles */
+  articles?: Maybe<ArticleConnection>;
+  /** single bureau with slug */
   bureau?: Maybe<Bureau>;
-  /** get all bureaus */
+  /** all bureaus */
   bureaus?: Maybe<Array<Bureau>>;
+};
+
+
+/** queries */
+export type QueryArticlesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -85,6 +150,169 @@ export default {
     "mutationType": null,
     "subscriptionType": null,
     "types": [
+      {
+        "kind": "OBJECT",
+        "name": "Article",
+        "fields": [
+          {
+            "name": "bureaus",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Bureau",
+                  "ofType": null
+                }
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "content",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "createdAt",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Any"
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "id",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Any"
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "number",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Any"
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "publishedAt",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "title",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Any"
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "updatedAt",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Any"
+              }
+            },
+            "args": []
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ArticleConnection",
+        "fields": [
+          {
+            "name": "edges",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ArticleEdge",
+                "ofType": null
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "nodes",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Article",
+                "ofType": null
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "pageInfo",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "args": []
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ArticleEdge",
+        "fields": [
+          {
+            "name": "cursor",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Any"
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "Article",
+              "ofType": null
+            },
+            "args": []
+          }
+        ],
+        "interfaces": []
+      },
       {
         "kind": "OBJECT",
         "name": "Bureau",
@@ -168,8 +396,91 @@ export default {
       },
       {
         "kind": "OBJECT",
+        "name": "PageInfo",
+        "fields": [
+          {
+            "name": "endCursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "hasNextPage",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Any"
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "hasPreviousPage",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Any"
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "startCursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "OBJECT",
         "name": "Query",
         "fields": [
+          {
+            "name": "articles",
+            "type": {
+              "kind": "OBJECT",
+              "name": "ArticleConnection",
+              "ofType": null
+            },
+            "args": [
+              {
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              }
+            ]
+          },
           {
             "name": "bureau",
             "type": {

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -18,47 +18,6 @@ export type Scalars = {
   ISO8601DateTime: { input: any; output: any; }
 };
 
-/** published article on Hoshinonaka Government */
-export type Article = {
-  __typename?: 'Article';
-  /** jurisdiction bureau */
-  bureaus?: Maybe<Array<Bureau>>;
-  /** markdown content */
-  content?: Maybe<Scalars['String']['output']>;
-  /** created at */
-  createdAt: Scalars['ISO8601DateTime']['output'];
-  /** id */
-  id: Scalars['ID']['output'];
-  /** category number */
-  number: Scalars['Int']['output'];
-  /** published at */
-  publishedAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
-  /** title */
-  title: Scalars['String']['output'];
-  /** updated at */
-  updatedAt: Scalars['ISO8601DateTime']['output'];
-};
-
-/** The connection type for Article. */
-export type ArticleConnection = {
-  __typename?: 'ArticleConnection';
-  /** A list of edges. */
-  edges?: Maybe<Array<Maybe<ArticleEdge>>>;
-  /** A list of nodes. */
-  nodes?: Maybe<Array<Maybe<Article>>>;
-  /** Information to aid in pagination. */
-  pageInfo: PageInfo;
-};
-
-/** An edge in a connection. */
-export type ArticleEdge = {
-  __typename?: 'ArticleEdge';
-  /** A cursor for use in pagination. */
-  cursor: Scalars['String']['output'];
-  /** The item at the end of the edge. */
-  node?: Maybe<Article>;
-};
-
 /** bureau model */
 export type Bureau = {
   __typename?: 'Bureau';
@@ -78,37 +37,13 @@ export type Bureau = {
   updatedAt: Scalars['ISO8601DateTime']['output'];
 };
 
-/** Information about pagination in a connection. */
-export type PageInfo = {
-  __typename?: 'PageInfo';
-  /** When paginating forwards, the cursor to continue. */
-  endCursor?: Maybe<Scalars['String']['output']>;
-  /** When paginating forwards, are there more items? */
-  hasNextPage: Scalars['Boolean']['output'];
-  /** When paginating backwards, are there more items? */
-  hasPreviousPage: Scalars['Boolean']['output'];
-  /** When paginating backwards, the cursor to continue. */
-  startCursor?: Maybe<Scalars['String']['output']>;
-};
-
 /** queries */
 export type Query = {
   __typename?: 'Query';
-  /** all published articles */
-  articles?: Maybe<ArticleConnection>;
-  /** single bureau with slug */
+  /** get single bureau with slug */
   bureau?: Maybe<Bureau>;
-  /** all bureaus */
+  /** get all bureaus */
   bureaus?: Maybe<Array<Bureau>>;
-};
-
-
-/** queries */
-export type QueryArticlesArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -150,169 +85,6 @@ export default {
     "mutationType": null,
     "subscriptionType": null,
     "types": [
-      {
-        "kind": "OBJECT",
-        "name": "Article",
-        "fields": [
-          {
-            "name": "bureaus",
-            "type": {
-              "kind": "LIST",
-              "ofType": {
-                "kind": "NON_NULL",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Bureau",
-                  "ofType": null
-                }
-              }
-            },
-            "args": []
-          },
-          {
-            "name": "content",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
-            },
-            "args": []
-          },
-          {
-            "name": "createdAt",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Any"
-              }
-            },
-            "args": []
-          },
-          {
-            "name": "id",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Any"
-              }
-            },
-            "args": []
-          },
-          {
-            "name": "number",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Any"
-              }
-            },
-            "args": []
-          },
-          {
-            "name": "publishedAt",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
-            },
-            "args": []
-          },
-          {
-            "name": "title",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Any"
-              }
-            },
-            "args": []
-          },
-          {
-            "name": "updatedAt",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Any"
-              }
-            },
-            "args": []
-          }
-        ],
-        "interfaces": []
-      },
-      {
-        "kind": "OBJECT",
-        "name": "ArticleConnection",
-        "fields": [
-          {
-            "name": "edges",
-            "type": {
-              "kind": "LIST",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "ArticleEdge",
-                "ofType": null
-              }
-            },
-            "args": []
-          },
-          {
-            "name": "nodes",
-            "type": {
-              "kind": "LIST",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Article",
-                "ofType": null
-              }
-            },
-            "args": []
-          },
-          {
-            "name": "pageInfo",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "PageInfo",
-                "ofType": null
-              }
-            },
-            "args": []
-          }
-        ],
-        "interfaces": []
-      },
-      {
-        "kind": "OBJECT",
-        "name": "ArticleEdge",
-        "fields": [
-          {
-            "name": "cursor",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Any"
-              }
-            },
-            "args": []
-          },
-          {
-            "name": "node",
-            "type": {
-              "kind": "OBJECT",
-              "name": "Article",
-              "ofType": null
-            },
-            "args": []
-          }
-        ],
-        "interfaces": []
-      },
       {
         "kind": "OBJECT",
         "name": "Bureau",
@@ -396,91 +168,8 @@ export default {
       },
       {
         "kind": "OBJECT",
-        "name": "PageInfo",
-        "fields": [
-          {
-            "name": "endCursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
-            },
-            "args": []
-          },
-          {
-            "name": "hasNextPage",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Any"
-              }
-            },
-            "args": []
-          },
-          {
-            "name": "hasPreviousPage",
-            "type": {
-              "kind": "NON_NULL",
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Any"
-              }
-            },
-            "args": []
-          },
-          {
-            "name": "startCursor",
-            "type": {
-              "kind": "SCALAR",
-              "name": "Any"
-            },
-            "args": []
-          }
-        ],
-        "interfaces": []
-      },
-      {
-        "kind": "OBJECT",
         "name": "Query",
         "fields": [
-          {
-            "name": "articles",
-            "type": {
-              "kind": "OBJECT",
-              "name": "ArticleConnection",
-              "ofType": null
-            },
-            "args": [
-              {
-                "name": "after",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "before",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "first",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              },
-              {
-                "name": "last",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Any"
-                }
-              }
-            ]
-          },
           {
             "name": "bureau",
             "type": {


### PR DESCRIPTION
**プルリクエスト提出前確認項目**
- [x] closeする各Issueの受け入れ条件をすべて満たしている
- [x] 実装ページや機能があればそれをWikiに掲載した
# Issue
- close #3 
- Epic: 
## 目的
フロントエンドからバックエンドのGraphQLにアクセスすることができる
## 実装詳細
- コンテナにネットワークを追加する
- リクエストするURLをローカルのコンテナに修正する
- READMEを現状に合わせて修正する
## 動作
- [x] READMEの手順でコンテナが立ち上がる
- [x] yarn generateでローカルのGraphQLをリクエストする

## レビュー観点

## デプロイ種別
### 種別（選択）
不要
### 追加作業／確認項目
- Snak0201/fpb-wwwsite#152 と同時にマージする
## メモ
