### PR TITLE
#1 記事一覧ページの実装

### DIFF
--- a/src/components/ArticleList/fragment.gql
+++ b/src/components/ArticleList/fragment.gql
@@ -1,9 +1,0 @@
-fragment ArticleList on ArticleConnection {
-  nodes {
-    ...ArticleNodesField
-  }
-}
-
-fragment ArticleNodesField on Article {
-  title
-}

--- a/src/components/ArticleList/fragment.gql
+++ b/src/components/ArticleList/fragment.gql
@@ -1,0 +1,9 @@
+fragment ArticleList on ArticleConnection {
+  nodes {
+    ...ArticleNodesField
+  }
+}
+
+fragment ArticleNodesField on Article {
+  title
+}

--- a/src/components/ArticleList/index.tsx
+++ b/src/components/ArticleList/index.tsx
@@ -1,7 +1,7 @@
 import { ArticleListFragment } from "@/graphql/generated"
 
 interface Props {
-  articles: ArticleListFragment
+  // articles: ArticleListFragment
 }
 
-export const ArticleList = () => {}
+export const ArticleList = () => <>ArticleList</>

--- a/src/components/ArticleList/index.tsx
+++ b/src/components/ArticleList/index.tsx
@@ -1,9 +1,0 @@
-import { ArticleListFragment } from "@/graphql/generated"
-
-interface Props {
-  articles: ArticleListFragment
-}
-
-export const ArticleList = ({ articles }: Props) => {
-  return <>ArticleList</>
-}

--- a/src/components/ArticleList/index.tsx
+++ b/src/components/ArticleList/index.tsx
@@ -1,0 +1,7 @@
+import { ArticleListFragment } from "@/graphql/generated"
+
+interface Props {
+  articles: ArticleListFragment
+}
+
+export const ArticleList = () => {}

--- a/src/components/ArticleList/index.tsx
+++ b/src/components/ArticleList/index.tsx
@@ -1,7 +1,9 @@
 import { ArticleListFragment } from "@/graphql/generated"
 
 interface Props {
-  // articles: ArticleListFragment
+  articles: ArticleListFragment
 }
 
-export const ArticleList = () => <>ArticleList</>
+export const ArticleList = ({ articles }: Props) => {
+  return <>ArticleList</>
+}

--- a/src/components/ArticleListItem/fragment.gql
+++ b/src/components/ArticleListItem/fragment.gql
@@ -3,6 +3,7 @@ fragment ArticleListItem on Article {
   title
   bureaus {
     name
+    slug
   }
   publishedAt
   updatedAt

--- a/src/components/ArticleListItem/fragment.gql
+++ b/src/components/ArticleListItem/fragment.gql
@@ -1,0 +1,8 @@
+fragment ArticleListItem on Article {
+  title
+  bureaus {
+    name
+  }
+  publishedAt
+  updatedAt
+}

--- a/src/components/ArticleListItem/fragment.gql
+++ b/src/components/ArticleListItem/fragment.gql
@@ -1,4 +1,5 @@
 fragment ArticleListItem on Article {
+  id
   title
   bureaus {
     name

--- a/src/components/ArticleListItem/index.tsx
+++ b/src/components/ArticleListItem/index.tsx
@@ -9,13 +9,24 @@ interface Props {
  * 記事一覧内の一アイテム
  */
 export const ArticleListItem = ({ article }: Props) => {
+  const published = new Date(article.publishedAt)
+
+  const formatter = new Intl.DateTimeFormat("ja-JP", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  })
+  const formattedDate = formatter.format(published)
+
   return (
     <div className={styles.card}>
-      <h2>{article.title}</h2>
-      <p>{article.updatedAt}</p>
-      <p>{article.publishedAt}</p>
+      <a href={`articles/${article.id}`}>{article.title}</a>
+      {!!formattedDate && <p>{formattedDate}</p>}
       {article.bureaus?.map((bureau) => (
-        <>{bureau.name}</>
+        <>{bureau.name}　</>
       ))}
     </div>
   )

--- a/src/components/ArticleListItem/index.tsx
+++ b/src/components/ArticleListItem/index.tsx
@@ -1,3 +1,4 @@
+import { styles } from "@/components/ArticleListItem/style.css"
 import { ArticleListItemFragment } from "@/graphql/generated"
 
 interface Props {
@@ -9,7 +10,7 @@ interface Props {
  */
 export const ArticleListItem = ({ article }: Props) => {
   return (
-    <div>
+    <div className={styles.card}>
       <p>{article.title}</p>
       <p>{article.updatedAt}</p>
       <p>{article.publishedAt}</p>

--- a/src/components/ArticleListItem/index.tsx
+++ b/src/components/ArticleListItem/index.tsx
@@ -1,0 +1,21 @@
+import { ArticleListItemFragment } from "@/graphql/generated"
+
+interface Props {
+  article: ArticleListItemFragment
+}
+
+/**
+ * 記事一覧内の一アイテム
+ */
+export const ArticleListItem = ({ article }: Props) => {
+  return (
+    <div>
+      <p>{article.title}</p>
+      <p>{article.updatedAt}</p>
+      <p>{article.publishedAt}</p>
+      {article.bureaus?.map((bureau) => (
+        <>{bureau.name}</>
+      ))}
+    </div>
+  )
+}

--- a/src/components/ArticleListItem/index.tsx
+++ b/src/components/ArticleListItem/index.tsx
@@ -1,5 +1,6 @@
 import { styles } from "@/components/ArticleListItem/style.css"
 import { ViewA } from "@/components/ViewA"
+import { formatDatetimezone } from "@/constants/format"
 import { ArticleListItemFragment } from "@/graphql/generated"
 
 interface Props {
@@ -10,20 +11,8 @@ interface Props {
  * 記事一覧内の一アイテム
  */
 export const ArticleListItem = ({ article }: Props) => {
-  /**
-   * タイムゾーン付きの日時文字列を変換する
-   *
-   * 2024-06-16T13:36:09+09:00 => 2024年06月16日 13時36分
-   *  */
-  const formattedPublishedAt = (datetimezoneString: string) => {
-    const dateString = datetimezoneString.split("T")[0]
-    const [yearString, monthString, dayString] = dateString.split("-")
-    const [hourString, minuteString] = datetimezoneString
-      .split("T")[1]
-      .split("+")[0]
-      .split(":")
-    return `${yearString}年${monthString}月${dayString}日 ${hourString}時${minuteString}分`
-  }
+  const publishedAt = formatDatetimezone(article.publishedAt)
+  const updatedAt = formatDatetimezone(article.updatedAt)
 
   return (
     <div className={styles.card}>
@@ -34,13 +23,6 @@ export const ArticleListItem = ({ article }: Props) => {
       >
         {article.title}
       </ViewA>
-
-      {!!article.publishedAt && (
-        <div>
-          <span className={styles.description}>公開日時:</span>
-          {formattedPublishedAt(article.publishedAt)}
-        </div>
-      )}
 
       {!!article.bureaus?.length && (
         <div>
@@ -55,6 +37,20 @@ export const ArticleListItem = ({ article }: Props) => {
               {bureau.name}
             </ViewA>
           ))}
+        </div>
+      )}
+
+      {!!publishedAt && (
+        <div>
+          <span className={styles.description}>公開日時:</span>
+          {publishedAt}
+        </div>
+      )}
+
+      {!!updatedAt && publishedAt !== updatedAt && (
+        <div>
+          <span className={styles.description}>更新日時:</span>
+          {updatedAt}
         </div>
       )}
     </div>

--- a/src/components/ArticleListItem/index.tsx
+++ b/src/components/ArticleListItem/index.tsx
@@ -29,16 +29,18 @@ export const ArticleListItem = ({ article }: Props) => {
       <a href={`articles/${article.id}`}>{article.title}</a>
 
       {!!article.publishedAt && (
-        <p>公開日時: {formattedPublishedAt(article.publishedAt)}</p>
+        <div>公開日時: {formattedPublishedAt(article.publishedAt)}</div>
       )}
 
       {!!article.bureaus?.length && (
-        <p>
-          管轄局:{" "}
+        <div>
+          管轄局:
           {article.bureaus.map((bureau, index) => (
-            <span key={index}>{bureau.name} </span>
+            <a href={`bureaus/${bureau.slug}`} key={index}>
+              {bureau.name}
+            </a>
           ))}
-        </p>
+        </div>
       )}
     </div>
   )

--- a/src/components/ArticleListItem/index.tsx
+++ b/src/components/ArticleListItem/index.tsx
@@ -26,17 +26,33 @@ export const ArticleListItem = ({ article }: Props) => {
 
   return (
     <div className={styles.card}>
-      <a href={`articles/${article.id}`}>{article.title}</a>
+      <a
+        className={styles.title}
+        href={`articles/${article.id}`}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {article.title}
+      </a>
 
       {!!article.publishedAt && (
-        <div>公開日時: {formattedPublishedAt(article.publishedAt)}</div>
+        <div>
+          <span className={styles.description}>公開日時:</span>
+          {formattedPublishedAt(article.publishedAt)}
+        </div>
       )}
 
       {!!article.bureaus?.length && (
         <div>
-          管轄局:
+          <span className={styles.description}>管轄局:</span>
           {article.bureaus.map((bureau, index) => (
-            <a href={`bureaus/${bureau.slug}`} key={index}>
+            <a
+              className={styles.bureau}
+              href={`bureaus/${bureau.slug}`}
+              key={index}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               {bureau.name}
             </a>
           ))}

--- a/src/components/ArticleListItem/index.tsx
+++ b/src/components/ArticleListItem/index.tsx
@@ -1,4 +1,5 @@
 import { styles } from "@/components/ArticleListItem/style.css"
+import { ViewA } from "@/components/ViewA"
 import { ArticleListItemFragment } from "@/graphql/generated"
 
 interface Props {
@@ -26,14 +27,13 @@ export const ArticleListItem = ({ article }: Props) => {
 
   return (
     <div className={styles.card}>
-      <a
-        className={styles.title}
+      <ViewA
         href={`articles/${article.id}`}
-        target="_blank"
-        rel="noopener noreferrer"
+        className={styles.title}
+        opensInNewTab={true}
       >
         {article.title}
-      </a>
+      </ViewA>
 
       {!!article.publishedAt && (
         <div>
@@ -46,15 +46,14 @@ export const ArticleListItem = ({ article }: Props) => {
         <div>
           <span className={styles.description}>管轄局:</span>
           {article.bureaus.map((bureau, index) => (
-            <a
-              className={styles.bureau}
-              href={`bureaus/${bureau.slug}`}
+            <ViewA
               key={index}
-              target="_blank"
-              rel="noopener noreferrer"
+              href={`bureaus/${bureau.slug}`}
+              className={styles.bureau}
+              opensInNewTab={true}
             >
               {bureau.name}
-            </a>
+            </ViewA>
           ))}
         </div>
       )}

--- a/src/components/ArticleListItem/index.tsx
+++ b/src/components/ArticleListItem/index.tsx
@@ -9,25 +9,37 @@ interface Props {
  * 記事一覧内の一アイテム
  */
 export const ArticleListItem = ({ article }: Props) => {
-  const published = new Date(article.publishedAt)
-
-  const formatter = new Intl.DateTimeFormat("ja-JP", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  })
-  const formattedDate = formatter.format(published)
+  /**
+   * タイムゾーン付きの日時文字列を変換する
+   *
+   * 2024-06-16T13:36:09+09:00 => 2024年06月16日 13時36分
+   *  */
+  const formattedPublishedAt = (datetimezoneString: string) => {
+    const dateString = datetimezoneString.split("T")[0]
+    const [yearString, monthString, dayString] = dateString.split("-")
+    const [hourString, minuteString] = datetimezoneString
+      .split("T")[1]
+      .split("+")[0]
+      .split(":")
+    return `${yearString}年${monthString}月${dayString}日 ${hourString}時${minuteString}分`
+  }
 
   return (
     <div className={styles.card}>
       <a href={`articles/${article.id}`}>{article.title}</a>
-      {!!formattedDate && <p>{formattedDate}</p>}
-      {article.bureaus?.map((bureau) => (
-        <>{bureau.name}　</>
-      ))}
+
+      {!!article.publishedAt && (
+        <p>公開日時: {formattedPublishedAt(article.publishedAt)}</p>
+      )}
+
+      {!!article.bureaus?.length && (
+        <p>
+          管轄局:{" "}
+          {article.bureaus.map((bureau, index) => (
+            <span key={index}>{bureau.name} </span>
+          ))}
+        </p>
+      )}
     </div>
   )
 }

--- a/src/components/ArticleListItem/index.tsx
+++ b/src/components/ArticleListItem/index.tsx
@@ -11,7 +11,7 @@ interface Props {
 export const ArticleListItem = ({ article }: Props) => {
   return (
     <div className={styles.card}>
-      <p>{article.title}</p>
+      <h2>{article.title}</h2>
       <p>{article.updatedAt}</p>
       <p>{article.publishedAt}</p>
       {article.bureaus?.map((bureau) => (

--- a/src/components/ArticleListItem/style.css.ts
+++ b/src/components/ArticleListItem/style.css.ts
@@ -6,4 +6,7 @@ export const styles = {
     padding: "5px",
     boxShadow: " 0 10px 25px 0 rgba(0, 0, 0, .2)",
   }),
+  title: style({ fontSize: "24px", textDecoration: "none" }),
+  description: style({ marginRight: "5px" }),
+  bureau: style({ textDecoration: "none", marginRight: "5px" }),
 }

--- a/src/components/ArticleListItem/style.css.ts
+++ b/src/components/ArticleListItem/style.css.ts
@@ -4,6 +4,6 @@ export const styles = {
   card: style({
     margin: "5px",
     padding: "5px",
-    boxShadow: " 0 10px 25px 0 rgba(0, 0, 0, .5)",
+    boxShadow: " 0 10px 25px 0 rgba(0, 0, 0, .2)",
   }),
 }

--- a/src/components/ArticleListItem/style.css.ts
+++ b/src/components/ArticleListItem/style.css.ts
@@ -1,0 +1,9 @@
+import { style } from "@vanilla-extract/css"
+
+export const styles = {
+  card: style({
+    margin: "5px",
+    padding: "5px",
+    boxShadow: " 0 10px 25px 0 rgba(0, 0, 0, .5)",
+  }),
+}

--- a/src/components/ArticleListItem/style.css.ts
+++ b/src/components/ArticleListItem/style.css.ts
@@ -1,3 +1,4 @@
+import { mediaQuery } from "@/constants/mediaQuery"
 import { style } from "@vanilla-extract/css"
 
 export const styles = {
@@ -6,7 +7,15 @@ export const styles = {
     padding: "5px",
     boxShadow: " 0 10px 25px 0 rgba(0, 0, 0, .2)",
   }),
-  title: style({ fontSize: "24px", textDecoration: "none" }),
+  title: style({
+    fontSize: "24px",
+    textDecoration: "none",
+    "@media": {
+      [mediaQuery.tab]: {
+        fontSize: "18px",
+      },
+    },
+  }),
   description: style({ marginRight: "5px" }),
   bureau: style({ textDecoration: "none", marginRight: "5px" }),
 }

--- a/src/components/ArticleListItem/style.css.ts
+++ b/src/components/ArticleListItem/style.css.ts
@@ -3,9 +3,9 @@ import { style } from "@vanilla-extract/css"
 
 export const styles = {
   card: style({
-    margin: "5px",
+    margin: "20px 5px",
     padding: "5px",
-    boxShadow: " 0 10px 25px 0 rgba(0, 0, 0, .2)",
+    boxShadow: " 0 10px 25px 0 rgba(0, 0, 0, .15)",
   }),
   title: style({
     fontSize: "24px",

--- a/src/components/ViewA/index.tsx
+++ b/src/components/ViewA/index.tsx
@@ -3,22 +3,22 @@ import { ReactNode } from "react"
 interface Props {
   href: string
   className?: string
-  isOpenNewTab?: boolean
+  opensInNewTab?: boolean
   children: ReactNode
 }
 
 /**
  * View共通でつかうaタグ
  *
- * 新しいタブを指定する場合、isOpenNewTabをtrueに設定する
+ * 新しいタブを指定する場合、opensInNewTabをtrueに設定する
  */
 export const ViewA = ({
   href,
   className = "",
-  isOpenNewTab = false,
+  opensInNewTab = false,
   children,
 }: Props) => {
-  if (!isOpenNewTab)
+  if (!opensInNewTab)
     return (
       <a href={href} className={className}>
         {children}

--- a/src/components/ViewA/index.tsx
+++ b/src/components/ViewA/index.tsx
@@ -1,0 +1,37 @@
+import { ReactNode } from "react"
+
+interface Props {
+  href: string
+  className?: string
+  isOpenNewTab?: boolean
+  children: ReactNode
+}
+
+/**
+ * View共通でつかうaタグ
+ *
+ * 新しいタブを指定する場合、isOpenNewTabをtrueに設定する
+ */
+export const ViewA = ({
+  href,
+  className = "",
+  isOpenNewTab = false,
+  children,
+}: Props) => {
+  if (!isOpenNewTab)
+    return (
+      <a href={href} className={className}>
+        {children}
+      </a>
+    )
+  return (
+    <a
+      href={href}
+      className={className}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {children}
+    </a>
+  )
+}

--- a/src/components/ViewButton/index.tsx
+++ b/src/components/ViewButton/index.tsx
@@ -1,0 +1,18 @@
+import { ReactNode } from "react"
+
+interface Props {
+  onClick?: () => void
+  className?: string
+  children: ReactNode
+}
+
+/**
+ * View共通のbuttonタグ
+ */
+export const ViewButton = ({ onClick, className, children }: Props) => {
+  return (
+    <button onClick={onClick} className={className}>
+      {children}
+    </button>
+  )
+}

--- a/src/components/ViewButton/index.tsx
+++ b/src/components/ViewButton/index.tsx
@@ -4,15 +4,26 @@ import { ReactNode } from "react"
 interface Props {
   onClick?: () => void
   className?: string
+  isHolizontal?: boolean
   children: ReactNode
 }
 
 /**
  * View共通のbuttonタグ
  */
-export const ViewButton = ({ onClick, className, children }: Props) => {
+export const ViewButton = ({
+  onClick,
+  className = "",
+  isHolizontal = false,
+  children,
+}: Props) => {
   return (
-    <button onClick={onClick} className={`${className} ${styles.normal}`}>
+    <button
+      onClick={onClick}
+      className={`${className} ${styles.normal} ${
+        isHolizontal ? "holizontal" : ""
+      }`}
+    >
       {children}
     </button>
   )

--- a/src/components/ViewButton/index.tsx
+++ b/src/components/ViewButton/index.tsx
@@ -1,3 +1,4 @@
+import { styles } from "@/components/ViewButton/style.css"
 import { ReactNode } from "react"
 
 interface Props {
@@ -11,7 +12,7 @@ interface Props {
  */
 export const ViewButton = ({ onClick, className, children }: Props) => {
   return (
-    <button onClick={onClick} className={className}>
+    <button onClick={onClick} className={`${className} ${styles.normal}`}>
       {children}
     </button>
   )

--- a/src/components/ViewButton/style.css.ts
+++ b/src/components/ViewButton/style.css.ts
@@ -1,0 +1,53 @@
+import { style } from "@vanilla-extract/css"
+
+export const styles = {
+  normal: style({
+    textAlign: "center",
+    textDecoration: "none",
+    marginRight: "auto",
+    padding: "1rem 4rem",
+    fontWeight: "bold",
+    fontSize: "20px",
+    border: "2px solid #4E5BA8",
+    color: "#FFFFFF",
+    backgroundColor: "#4E5BA8",
+    borderRadius: "100vh",
+    transition: "0.5s",
+    display: "block",
+    ":hover": {
+      color: "#4E5BA8",
+      backgroundColor: "#FFFFFF",
+    },
+    selectors: {
+      "&.holizontal": {
+        display: "inline",
+        marginRight: "10px",
+      },
+    },
+  }),
+
+  danger: style({
+    textAlign: "center",
+    textDecoration: "none",
+    marginRight: "auto",
+    padding: "1rem 4rem",
+    fontWeight: "bold",
+    fontSize: "20px",
+    border: "2px solid #F05A5A",
+    color: "#FFFFFF",
+    backgroundColor: "#F05A5A",
+    borderRadius: "100vh",
+    transition: "0.5s",
+    display: "block",
+    ":hover": {
+      color: "#F05A5A",
+      backgroundColor: "#FFFFFF",
+    },
+    selectors: {
+      "&.holizontal": {
+        display: "inline",
+        marginRight: "10px",
+      },
+    },
+  }),
+}

--- a/src/components/ViewButton/style.css.ts
+++ b/src/components/ViewButton/style.css.ts
@@ -1,3 +1,4 @@
+import { mediaQuery } from "@/constants/mediaQuery"
 import { style } from "@vanilla-extract/css"
 
 export const styles = {
@@ -14,9 +15,15 @@ export const styles = {
     borderRadius: "100vh",
     transition: "0.5s",
     display: "block",
+
     ":hover": {
       color: "#4E5BA8",
       backgroundColor: "#FFFFFF",
+    },
+    "@media": {
+      [mediaQuery.tab]: {
+        padding: "1rem 2.5rem",
+      },
     },
     selectors: {
       "&.holizontal": {

--- a/src/components/ViewButton/style.css.ts
+++ b/src/components/ViewButton/style.css.ts
@@ -1,3 +1,4 @@
+import { color } from "@/constants/color"
 import { mediaQuery } from "@/constants/mediaQuery"
 import { style } from "@vanilla-extract/css"
 
@@ -9,16 +10,16 @@ export const styles = {
     padding: "1rem 4rem",
     fontWeight: "bold",
     fontSize: "20px",
-    border: "2px solid #4E5BA8",
-    color: "#FFFFFF",
-    backgroundColor: "#4E5BA8",
+    border: `2px solid ${color.blue}`,
+    color: color.white,
+    backgroundColor: color.blue,
     borderRadius: "100vh",
     transition: "0.5s",
     display: "block",
 
     ":hover": {
-      color: "#4E5BA8",
-      backgroundColor: "#FFFFFF",
+      color: color.blue,
+      backgroundColor: color.white,
     },
     "@media": {
       [mediaQuery.tab]: {
@@ -40,15 +41,15 @@ export const styles = {
     padding: "1rem 4rem",
     fontWeight: "bold",
     fontSize: "20px",
-    border: "2px solid #F05A5A",
-    color: "#FFFFFF",
-    backgroundColor: "#F05A5A",
+    border: `2px solid ${color.alertRed}`,
+    color: color.white,
+    backgroundColor: color.alertRed,
     borderRadius: "100vh",
     transition: "0.5s",
     display: "block",
     ":hover": {
-      color: "#F05A5A",
-      backgroundColor: "#FFFFFF",
+      color: color.alertRed,
+      backgroundColor: color.white,
     },
     selectors: {
       "&.holizontal": {

--- a/src/components/ViewContainer/index.tsx
+++ b/src/components/ViewContainer/index.tsx
@@ -6,7 +6,7 @@ interface Props {
 }
 
 /**
- * 画面サイズの制御コンポーネント
+ * View共通の画面サイズの制御コンポーネント
  */
 export const ViewContainer = ({ children }: Props) => {
   return <div className={styles.container}>{children}</div>

--- a/src/components/ViewFooter/index.tsx
+++ b/src/components/ViewFooter/index.tsx
@@ -1,5 +1,8 @@
 import { styles } from "@/components/ViewFooter/style.css"
 
+/**
+ * View共通で使うフッター
+ */
 export const ViewFooter = () => {
   return (
     <div className={styles.footer}>

--- a/src/components/ViewHeader/index.tsx
+++ b/src/components/ViewHeader/index.tsx
@@ -8,7 +8,7 @@ interface NavLink {
 }
 
 /**
- * ヘッダー
+ * View共通で使うヘッダー
  */
 export const ViewHeader = () => {
   const navLinks: NavLink[] = [

--- a/src/components/pages/articles/fragment.gql
+++ b/src/components/pages/articles/fragment.gql
@@ -4,7 +4,9 @@ fragment ArticlesPage on ArticleConnection {
   }
 
   pageInfo {
+    startCursor
     endCursor
+    hasPreviousPage
     hasNextPage
   }
 }

--- a/src/components/pages/articles/fragment.gql
+++ b/src/components/pages/articles/fragment.gql
@@ -7,6 +7,13 @@ fragment ArticlesPage on ArticleConnection {
     endCursor
     hasNextPage
   }
+}
 
-  ...ArticleList
+fragment ArticleNodesField on Article {
+  title
+  bureaus {
+    name
+  }
+  publishedAt
+  updatedAt
 }

--- a/src/components/pages/articles/fragment.gql
+++ b/src/components/pages/articles/fragment.gql
@@ -6,13 +6,3 @@ fragment ArticlesPage on ArticleConnection {
     hasNextPage
   }
 }
-
-fragment ArticleList on ArticleConnection {
-  nodes {
-    ...ArticleListField
-  }
-}
-
-fragment ArticleListField on Article {
-  title
-}

--- a/src/components/pages/articles/fragment.gql
+++ b/src/components/pages/articles/fragment.gql
@@ -1,8 +1,12 @@
 fragment ArticlesPage on ArticleConnection {
-  ...ArticleList
+  nodes {
+    ...ArticleNodesField
+  }
 
   pageInfo {
     endCursor
     hasNextPage
   }
+
+  ...ArticleList
 }

--- a/src/components/pages/articles/fragment.gql
+++ b/src/components/pages/articles/fragment.gql
@@ -1,19 +1,10 @@
 fragment ArticlesPage on ArticleConnection {
   nodes {
-    ...ArticleNodesField
+    ...ArticleListItem
   }
 
   pageInfo {
     endCursor
     hasNextPage
   }
-}
-
-fragment ArticleNodesField on Article {
-  title
-  bureaus {
-    name
-  }
-  publishedAt
-  updatedAt
 }

--- a/src/components/pages/articles/fragment.gql
+++ b/src/components/pages/articles/fragment.gql
@@ -1,0 +1,18 @@
+fragment ArticlesPage on ArticleConnection {
+  ...ArticleList
+
+  pageInfo {
+    endCursor
+    hasNextPage
+  }
+}
+
+fragment ArticleList on ArticleConnection {
+  nodes {
+    ...ArticleListField
+  }
+}
+
+fragment ArticleListField on Article {
+  title
+}

--- a/src/components/pages/articles/index.tsx
+++ b/src/components/pages/articles/index.tsx
@@ -1,0 +1,3 @@
+export const ArticlesPageComponent = () => {
+  return <>ArticlesPageComponent</>
+}

--- a/src/components/pages/articles/index.tsx
+++ b/src/components/pages/articles/index.tsx
@@ -1,3 +1,9 @@
+import { articlesPageAtom } from "@/store/article"
+import { useAtomValue } from "jotai"
+
 export const ArticlesPageComponent = () => {
+  const articlesPage = useAtomValue(articlesPageAtom)
+  console.log(articlesPage)
+
   return <>ArticlesPageComponent</>
 }

--- a/src/components/pages/articles/index.tsx
+++ b/src/components/pages/articles/index.tsx
@@ -1,4 +1,3 @@
-import { ArticleList } from "@/components/ArticleList"
 import { ViewContainer } from "@/components/ViewContainer"
 import { ViewLayout } from "@/layouts"
 import { articlesPageAtom } from "@/store/article"
@@ -12,11 +11,11 @@ export const ArticlesPageComponent = () => {
   return (
     <ViewLayout title="記事一覧">
       <ViewContainer>
-        <ArticleList articles={articles} />
-        {/* {articles.map((article, index) => {
+        <h1>記事一覧</h1>
+        {articles.nodes?.map((article, index) => {
           if (!article) return
           return <p key={index}>{article.title}</p>
-        })} */}
+        })}
       </ViewContainer>
     </ViewLayout>
   )

--- a/src/components/pages/articles/index.tsx
+++ b/src/components/pages/articles/index.tsx
@@ -19,9 +19,19 @@ export const ArticlesPageComponent = () => {
     pause: true,
   })
 
+  const getNextArticles = () => {
+    csrNextQuery(csrOptions)
+  }
+
+  useEffect(() => {
+    if (!csrNextArticles.data?.articles) return
+
+    setArticles(csrNextArticles.data?.articles)
+  }, [csrNextArticles.data?.articles])
+
   const [csrPreviousArticles, csrPrivousQuery] = useGetArticlesPageQuery({
     variables: {
-      endCursor: articles.pageInfo.startCursor,
+      startCursor: articles.pageInfo.startCursor,
     },
     pause: true,
   })
@@ -30,21 +40,11 @@ export const ArticlesPageComponent = () => {
     csrPrivousQuery(csrOptions)
   }
 
-  const getNextArticles = () => {
-    csrNextQuery(csrOptions)
-  }
-
   useEffect(() => {
     if (!csrPreviousArticles.data?.articles) return
 
     setArticles(csrPreviousArticles.data?.articles)
   }, [csrPreviousArticles.data?.articles])
-
-  useEffect(() => {
-    if (!csrNextArticles.data?.articles) return
-
-    setArticles(csrNextArticles.data?.articles)
-  }, [csrNextArticles.data?.articles])
 
   if (!articles) return
 

--- a/src/components/pages/articles/index.tsx
+++ b/src/components/pages/articles/index.tsx
@@ -5,19 +5,18 @@ import { articlesPageAtom } from "@/store/article"
 import { useAtomValue } from "jotai"
 
 export const ArticlesPageComponent = () => {
-  const articlesPage = useAtomValue(articlesPageAtom)
-  const articles = articlesPage.nodes
+  const articles = useAtomValue(articlesPageAtom)
 
   if (!articles) return
 
   return (
     <ViewLayout title="記事一覧">
       <ViewContainer>
-        <ArticleList />
-        {articles.map((article, index) => {
+        <ArticleList articles={articles} />
+        {/* {articles.map((article, index) => {
           if (!article) return
           return <p key={index}>{article.title}</p>
-        })}
+        })} */}
       </ViewContainer>
     </ViewLayout>
   )

--- a/src/components/pages/articles/index.tsx
+++ b/src/components/pages/articles/index.tsx
@@ -8,7 +8,7 @@ import { articlesPageAtom } from "@/store/article"
 import { useAtomValue } from "jotai"
 import { useEffect, useState } from "react"
 
-export const PAGINATE_ARTICLES_PER = 10
+export const PAGINATE_ARTICLES_PER = 5
 
 export const ArticlesPageComponent = () => {
   const ssrArticles = useAtomValue(articlesPageAtom)
@@ -68,12 +68,18 @@ export const ArticlesPageComponent = () => {
           if (!article) return
           return <ArticleListItem article={article} key={index} />
         })}
-        {articles.pageInfo.hasPreviousPage && (
-          <ViewButton onClick={getPreviousArticles}>前へ</ViewButton>
-        )}
-        {articles.pageInfo.hasNextPage && (
-          <ViewButton onClick={getNextArticles}>次へ</ViewButton>
-        )}
+        <div>
+          {articles.pageInfo.hasPreviousPage && (
+            <ViewButton onClick={getPreviousArticles} isHolizontal={true}>
+              前へ
+            </ViewButton>
+          )}
+          {articles.pageInfo.hasNextPage && (
+            <ViewButton onClick={getNextArticles} isHolizontal={true}>
+              次へ
+            </ViewButton>
+          )}
+        </div>
       </ViewContainer>
     </ViewLayout>
   )

--- a/src/components/pages/articles/index.tsx
+++ b/src/components/pages/articles/index.tsx
@@ -46,6 +46,10 @@ export const ArticlesPageComponent = () => {
     setArticles(csrPreviousArticles.data?.articles)
   }, [csrPreviousArticles.data?.articles])
 
+  useEffect(() => {
+    console.log(articles.pageInfo)
+  }, [articles])
+
   if (!articles) return
 
   return (

--- a/src/components/pages/articles/index.tsx
+++ b/src/components/pages/articles/index.tsx
@@ -19,6 +19,11 @@ export const ArticlesPageComponent = () => {
       first: PAGINATE_ARTICLES_PER,
       endCursor: articles.pageInfo.endCursor,
     },
+    /**
+     * NOTE: ページネーションの「戻って進む」動作のとき
+     * キャッシュが効いてクエリが動かないため、
+     * キャッシュを使いつつクエリも飛ばすようにしている
+     */
     requestPolicy: "cache-and-network",
     pause: true,
   })

--- a/src/components/pages/articles/index.tsx
+++ b/src/components/pages/articles/index.tsx
@@ -3,7 +3,16 @@ import { useAtomValue } from "jotai"
 
 export const ArticlesPageComponent = () => {
   const articlesPage = useAtomValue(articlesPageAtom)
-  console.log(articlesPage)
+  const articles = articlesPage.nodes
 
-  return <>ArticlesPageComponent</>
+  if (!articles) return
+
+  return (
+    <>
+      {articles.map((article, index) => {
+        if (!article) return
+        return <p key={index}>{article.title}</p>
+      })}
+    </>
+  )
 }

--- a/src/components/pages/articles/index.tsx
+++ b/src/components/pages/articles/index.tsx
@@ -8,7 +8,7 @@ import { articlesPageAtom } from "@/store/article"
 import { useAtomValue } from "jotai"
 import { useEffect, useState } from "react"
 
-export const PAGINATE_ARTICLES_PER = 10
+export const ARTICLES_PER_PAGE = 10
 
 export const ArticlesPageComponent = () => {
   const ssrArticles = useAtomValue(articlesPageAtom)
@@ -17,7 +17,7 @@ export const ArticlesPageComponent = () => {
 
   const [csrNextArticles, csrNextQuery] = useGetArticlesPageQuery({
     variables: {
-      first: PAGINATE_ARTICLES_PER,
+      first: ARTICLES_PER_PAGE,
       endCursor: articles.pageInfo.endCursor,
     },
     /**
@@ -41,7 +41,7 @@ export const ArticlesPageComponent = () => {
 
   const [csrPreviousArticles, csrPrivousQuery] = useGetArticlesPageQuery({
     variables: {
-      last: PAGINATE_ARTICLES_PER,
+      last: ARTICLES_PER_PAGE,
       startCursor: articles.pageInfo.startCursor,
     },
     requestPolicy: "cache-and-network",

--- a/src/components/pages/articles/index.tsx
+++ b/src/components/pages/articles/index.tsx
@@ -1,3 +1,5 @@
+import { ViewContainer } from "@/components/ViewContainer"
+import { ViewLayout } from "@/layouts"
 import { articlesPageAtom } from "@/store/article"
 import { useAtomValue } from "jotai"
 
@@ -8,11 +10,13 @@ export const ArticlesPageComponent = () => {
   if (!articles) return
 
   return (
-    <>
-      {articles.map((article, index) => {
-        if (!article) return
-        return <p key={index}>{article.title}</p>
-      })}
-    </>
+    <ViewLayout title="記事一覧">
+      <ViewContainer>
+        {articles.map((article, index) => {
+          if (!article) return
+          return <p key={index}>{article.title}</p>
+        })}
+      </ViewContainer>
+    </ViewLayout>
   )
 }

--- a/src/components/pages/articles/index.tsx
+++ b/src/components/pages/articles/index.tsx
@@ -1,3 +1,4 @@
+import { ArticleList } from "@/components/ArticleList"
 import { ViewContainer } from "@/components/ViewContainer"
 import { ViewLayout } from "@/layouts"
 import { articlesPageAtom } from "@/store/article"
@@ -12,6 +13,7 @@ export const ArticlesPageComponent = () => {
   return (
     <ViewLayout title="記事一覧">
       <ViewContainer>
+        <ArticleList />
         {articles.map((article, index) => {
           if (!article) return
           return <p key={index}>{article.title}</p>

--- a/src/components/pages/articles/index.tsx
+++ b/src/components/pages/articles/index.tsx
@@ -12,22 +12,39 @@ export const ArticlesPageComponent = () => {
 
   const [articles, setArticles] = useState(ssrArticles)
 
-  const [csrArticles, csrQuery] = useGetArticlesPageQuery({
+  const [csrNextArticles, csrNextQuery] = useGetArticlesPageQuery({
     variables: {
       endCursor: articles.pageInfo.endCursor,
     },
     pause: true,
   })
 
-  const getArticles = () => {
-    csrQuery(csrOptions)
+  const [csrPreviousArticles, csrPrivousQuery] = useGetArticlesPageQuery({
+    variables: {
+      endCursor: articles.pageInfo.startCursor,
+    },
+    pause: true,
+  })
+
+  const getPreviousArticles = () => {
+    csrPrivousQuery(csrOptions)
+  }
+
+  const getNextArticles = () => {
+    csrNextQuery(csrOptions)
   }
 
   useEffect(() => {
-    if (!csrArticles.data?.articles) return
+    if (!csrPreviousArticles.data?.articles) return
 
-    setArticles(csrArticles.data?.articles)
-  }, [csrArticles.data?.articles])
+    setArticles(csrPreviousArticles.data?.articles)
+  }, [csrPreviousArticles.data?.articles])
+
+  useEffect(() => {
+    if (!csrNextArticles.data?.articles) return
+
+    setArticles(csrNextArticles.data?.articles)
+  }, [csrNextArticles.data?.articles])
 
   if (!articles) return
 
@@ -39,8 +56,11 @@ export const ArticlesPageComponent = () => {
           if (!article) return
           return <ArticleListItem article={article} key={index} />
         })}
+        {articles.pageInfo.hasPreviousPage && (
+          <button onClick={getPreviousArticles}>前へ</button>
+        )}
         {articles.pageInfo.hasNextPage && (
-          <button onClick={getArticles}>次へ</button>
+          <button onClick={getNextArticles}>次へ</button>
         )}
       </ViewContainer>
     </ViewLayout>

--- a/src/components/pages/articles/index.tsx
+++ b/src/components/pages/articles/index.tsx
@@ -7,6 +7,8 @@ import { articlesPageAtom } from "@/store/article"
 import { useAtomValue } from "jotai"
 import { useEffect, useState } from "react"
 
+export const PAGINATE_ARTICLES_PER = 10
+
 export const ArticlesPageComponent = () => {
   const ssrArticles = useAtomValue(articlesPageAtom)
 
@@ -14,8 +16,10 @@ export const ArticlesPageComponent = () => {
 
   const [csrNextArticles, csrNextQuery] = useGetArticlesPageQuery({
     variables: {
+      first: PAGINATE_ARTICLES_PER,
       endCursor: articles.pageInfo.endCursor,
     },
+    requestPolicy: "cache-and-network",
     pause: true,
   })
 
@@ -31,8 +35,10 @@ export const ArticlesPageComponent = () => {
 
   const [csrPreviousArticles, csrPrivousQuery] = useGetArticlesPageQuery({
     variables: {
+      last: PAGINATE_ARTICLES_PER,
       startCursor: articles.pageInfo.startCursor,
     },
+    requestPolicy: "cache-and-network",
     pause: true,
   })
 
@@ -45,10 +51,6 @@ export const ArticlesPageComponent = () => {
 
     setArticles(csrPreviousArticles.data?.articles)
   }, [csrPreviousArticles.data?.articles])
-
-  useEffect(() => {
-    console.log(articles.pageInfo)
-  }, [articles])
 
   if (!articles) return
 

--- a/src/components/pages/articles/index.tsx
+++ b/src/components/pages/articles/index.tsx
@@ -1,4 +1,5 @@
 import { ArticleListItem } from "@/components/ArticleListItem"
+import { ViewButton } from "@/components/ViewButton"
 import { ViewContainer } from "@/components/ViewContainer"
 import { csrOptions } from "@/constants/urql"
 import { useGetArticlesPageQuery } from "@/graphql/generated"
@@ -68,10 +69,10 @@ export const ArticlesPageComponent = () => {
           return <ArticleListItem article={article} key={index} />
         })}
         {articles.pageInfo.hasPreviousPage && (
-          <button onClick={getPreviousArticles}>前へ</button>
+          <ViewButton onClick={getPreviousArticles}>前へ</ViewButton>
         )}
         {articles.pageInfo.hasNextPage && (
-          <button onClick={getNextArticles}>次へ</button>
+          <ViewButton onClick={getNextArticles}>次へ</ViewButton>
         )}
       </ViewContainer>
     </ViewLayout>

--- a/src/components/pages/articles/index.tsx
+++ b/src/components/pages/articles/index.tsx
@@ -1,3 +1,4 @@
+import { ArticleListItem } from "@/components/ArticleListItem"
 import { ViewContainer } from "@/components/ViewContainer"
 import { ViewLayout } from "@/layouts"
 import { articlesPageAtom } from "@/store/article"
@@ -14,16 +15,7 @@ export const ArticlesPageComponent = () => {
         <h1>記事一覧</h1>
         {articles.nodes?.map((article, index) => {
           if (!article) return
-          return (
-            <div key={index}>
-              <p>{article.title}</p>
-              <p>{article.updatedAt}</p>
-              <p>{article.publishedAt}</p>
-              {article.bureaus?.map((bureau) => (
-                <>{bureau.name}</>
-              ))}
-            </div>
-          )
+          return <ArticleListItem article={article} key={index} />
         })}
       </ViewContainer>
     </ViewLayout>

--- a/src/components/pages/articles/index.tsx
+++ b/src/components/pages/articles/index.tsx
@@ -8,7 +8,7 @@ import { articlesPageAtom } from "@/store/article"
 import { useAtomValue } from "jotai"
 import { useEffect, useState } from "react"
 
-export const PAGINATE_ARTICLES_PER = 5
+export const PAGINATE_ARTICLES_PER = 10
 
 export const ArticlesPageComponent = () => {
   const ssrArticles = useAtomValue(articlesPageAtom)

--- a/src/components/pages/articles/index.tsx
+++ b/src/components/pages/articles/index.tsx
@@ -69,14 +69,14 @@ export const ArticlesPageComponent = () => {
           return <ArticleListItem article={article} key={index} />
         })}
         <div>
-          {articles.pageInfo.hasPreviousPage && (
-            <ViewButton onClick={getPreviousArticles} isHolizontal={true}>
-              前へ
-            </ViewButton>
-          )}
           {articles.pageInfo.hasNextPage && (
             <ViewButton onClick={getNextArticles} isHolizontal={true}>
               次へ
+            </ViewButton>
+          )}
+          {articles.pageInfo.hasPreviousPage && (
+            <ViewButton onClick={getPreviousArticles} isHolizontal={true}>
+              前へ
             </ViewButton>
           )}
         </div>

--- a/src/components/pages/articles/index.tsx
+++ b/src/components/pages/articles/index.tsx
@@ -14,7 +14,16 @@ export const ArticlesPageComponent = () => {
         <h1>記事一覧</h1>
         {articles.nodes?.map((article, index) => {
           if (!article) return
-          return <p key={index}>{article.title}</p>
+          return (
+            <div key={index}>
+              <p>{article.title}</p>
+              <p>{article.updatedAt}</p>
+              <p>{article.publishedAt}</p>
+              {article.bureaus?.map((bureau) => (
+                <>{bureau.name}</>
+              ))}
+            </div>
+          )
         })}
       </ViewContainer>
     </ViewLayout>

--- a/src/components/pages/bureaus/index.tsx
+++ b/src/components/pages/bureaus/index.tsx
@@ -3,6 +3,7 @@ import { useAtomValue } from "jotai"
 import { styles } from "@/components/pages/bureaus/style.css"
 import { useGetBureauQuery } from "@/graphql/generated"
 import { csrOptions } from "@/constants/urql"
+import { ViewA } from "@/components/ViewA"
 
 export const BureausPageComponent = () => {
   const bureaus = useAtomValue(bureausAtom)
@@ -20,6 +21,7 @@ export const BureausPageComponent = () => {
         <div key={i}>{bureau.name}</div>
       ))}
       <button onClick={getBureau}>局取得</button>
+      <ViewA href="/">トップ</ViewA>
     </>
   )
 }

--- a/src/components/pages/bureaus/index.tsx
+++ b/src/components/pages/bureaus/index.tsx
@@ -5,6 +5,10 @@ import { useGetBureauQuery } from "@/graphql/generated"
 import { csrOptions } from "@/constants/urql"
 import { ViewA } from "@/components/ViewA"
 
+/**
+ * 局一覧ページ
+ * （開発用ページ）
+ */
 export const BureausPageComponent = () => {
   const bureaus = useAtomValue(bureausAtom)
 

--- a/src/constants/color.ts
+++ b/src/constants/color.ts
@@ -1,0 +1,10 @@
+export const characterColor = {
+  aoi_ipr: "#4E5BA8",
+  xue_wds: "#F05A5A",
+}
+
+export const color = {
+  blue: characterColor.aoi_ipr,
+  alertRed: characterColor.xue_wds,
+  white: "#FFFFFF",
+}

--- a/src/constants/format.ts
+++ b/src/constants/format.ts
@@ -1,0 +1,14 @@
+/**
+ * GQLから取得したタイムゾーン付きの日時文字列を変換する
+ *
+ * 2024-06-16T13:36:09+09:00 => 2024年06月16日 13時36分
+ *  */
+export const formatDatetimezone = (datetimezoneString: string) => {
+  const dateString = datetimezoneString.split("T")[0]
+  const [yearString, monthString, dayString] = dateString.split("-")
+  const [hourString, minuteString] = datetimezoneString
+    .split("T")[1]
+    .split("+")[0]
+    .split(":")
+  return `${yearString}年${monthString}月${dayString}日 ${hourString}時${minuteString}分`
+}

--- a/src/constants/urql.ts
+++ b/src/constants/urql.ts
@@ -1,6 +1,25 @@
+import { initUrqlClient } from "next-urql"
+import { cacheExchange, fetchExchange, ssrExchange } from "urql"
+
 /**
  * CSR時に指定するオプション
  */
 export const csrOptions = {
   url: `${process.env.NEXT_PUBLIC_WWWSITE_ROOT}graphql`,
+}
+
+/**
+ * SSR時のクライアントを作成する
+ */
+export const ssrClient = () => {
+  const ssrCache = ssrExchange({ isClient: false })
+  const client = initUrqlClient(
+    {
+      url: `${process.env.NEXT_PUBLIC_WWWSITE_CONTAINER_ROOT}graphql`,
+      exchanges: [cacheExchange, ssrCache, fetchExchange],
+    },
+    false
+  )
+
+  return { ssrCache: ssrCache, client: client }
 }

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -123,6 +123,7 @@ export type ArticlesPageFragment = { __typename?: 'ArticleConnection', nodes?: A
 
 export type GetArticlesPageQueryVariables = Exact<{
   first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
   endCursor?: InputMaybe<Scalars['String']['input']>;
   startCursor?: InputMaybe<Scalars['String']['input']>;
 }>;
@@ -174,8 +175,8 @@ export const BureausFragmentDoc = gql`
 }
     `;
 export const GetArticlesPageDocument = gql`
-    query GetArticlesPage($first: Int = 5, $endCursor: String, $startCursor: String) {
-  articles(first: $first, after: $endCursor, before: $startCursor) {
+    query GetArticlesPage($first: Int, $last: Int, $endCursor: String, $startCursor: String) {
+  articles(first: $first, last: $last, after: $endCursor, before: $startCursor) {
     ...ArticlesPage
   }
 }

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -18,6 +18,47 @@ export type Scalars = {
   ISO8601DateTime: { input: any; output: any; }
 };
 
+/** published article on Hoshinonaka Government */
+export type Article = {
+  __typename?: 'Article';
+  /** jurisdiction bureau */
+  bureaus?: Maybe<Array<Bureau>>;
+  /** markdown content */
+  content?: Maybe<Scalars['String']['output']>;
+  /** created at */
+  createdAt: Scalars['ISO8601DateTime']['output'];
+  /** id */
+  id: Scalars['ID']['output'];
+  /** category number */
+  number: Scalars['Int']['output'];
+  /** published at */
+  publishedAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
+  /** title */
+  title: Scalars['String']['output'];
+  /** updated at */
+  updatedAt: Scalars['ISO8601DateTime']['output'];
+};
+
+/** The connection type for Article. */
+export type ArticleConnection = {
+  __typename?: 'ArticleConnection';
+  /** A list of edges. */
+  edges?: Maybe<Array<Maybe<ArticleEdge>>>;
+  /** A list of nodes. */
+  nodes?: Maybe<Array<Maybe<Article>>>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+};
+
+/** An edge in a connection. */
+export type ArticleEdge = {
+  __typename?: 'ArticleEdge';
+  /** A cursor for use in pagination. */
+  cursor: Scalars['String']['output'];
+  /** The item at the end of the edge. */
+  node?: Maybe<Article>;
+};
+
 /** bureau model */
 export type Bureau = {
   __typename?: 'Bureau';
@@ -37,13 +78,37 @@ export type Bureau = {
   updatedAt: Scalars['ISO8601DateTime']['output'];
 };
 
+/** Information about pagination in a connection. */
+export type PageInfo = {
+  __typename?: 'PageInfo';
+  /** When paginating forwards, the cursor to continue. */
+  endCursor?: Maybe<Scalars['String']['output']>;
+  /** When paginating forwards, are there more items? */
+  hasNextPage: Scalars['Boolean']['output'];
+  /** When paginating backwards, are there more items? */
+  hasPreviousPage: Scalars['Boolean']['output'];
+  /** When paginating backwards, the cursor to continue. */
+  startCursor?: Maybe<Scalars['String']['output']>;
+};
+
 /** queries */
 export type Query = {
   __typename?: 'Query';
-  /** get single bureau with slug */
+  /** all published articles */
+  articles?: Maybe<ArticleConnection>;
+  /** single bureau with slug */
   bureau?: Maybe<Bureau>;
-  /** get all bureaus */
+  /** all bureaus */
   bureaus?: Maybe<Array<Bureau>>;
+};
+
+
+/** queries */
+export type QueryArticlesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -51,6 +116,19 @@ export type Query = {
 export type QueryBureauArgs = {
   slug: Scalars['String']['input'];
 };
+
+export type ArticlesPageFragment = { __typename?: 'ArticleConnection', pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean }, nodes?: Array<{ __typename?: 'Article', title: string } | null> | null };
+
+export type ArticleListFragment = { __typename?: 'ArticleConnection', nodes?: Array<{ __typename?: 'Article', title: string } | null> | null };
+
+export type ArticleListFieldFragment = { __typename?: 'Article', title: string };
+
+export type GetArticlesQueryVariables = Exact<{
+  first?: InputMaybe<Scalars['Int']['input']>;
+}>;
+
+
+export type GetArticlesQuery = { __typename?: 'Query', articles?: { __typename?: 'ArticleConnection', pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean }, nodes?: Array<{ __typename?: 'Article', title: string } | null> | null } | null };
 
 export type GetBureausQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -64,6 +142,27 @@ export type GetBureauQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type GetBureauQuery = { __typename?: 'Query', bureau?: { __typename?: 'Bureau', id: string } | null };
 
+export const ArticleListFieldFragmentDoc = gql`
+    fragment ArticleListField on Article {
+  title
+}
+    `;
+export const ArticleListFragmentDoc = gql`
+    fragment ArticleList on ArticleConnection {
+  nodes {
+    ...ArticleListField
+  }
+}
+    ${ArticleListFieldFragmentDoc}`;
+export const ArticlesPageFragmentDoc = gql`
+    fragment ArticlesPage on ArticleConnection {
+  ...ArticleList
+  pageInfo {
+    endCursor
+    hasNextPage
+  }
+}
+    ${ArticleListFragmentDoc}`;
 export const BureausFragmentDoc = gql`
     fragment bureaus on Bureau {
   id
@@ -71,6 +170,17 @@ export const BureausFragmentDoc = gql`
   description
 }
     `;
+export const GetArticlesDocument = gql`
+    query GetArticles($first: Int = 10) {
+  articles(first: $first) {
+    ...ArticlesPage
+  }
+}
+    ${ArticlesPageFragmentDoc}`;
+
+export function useGetArticlesQuery(options?: Omit<Urql.UseQueryArgs<GetArticlesQueryVariables>, 'query'>) {
+  return Urql.useQuery<GetArticlesQuery, GetArticlesQueryVariables>({ query: GetArticlesDocument, ...options });
+};
 export const GetBureausDocument = gql`
     query GetBureaus {
   bureaus {
@@ -102,6 +212,169 @@ export default {
     "mutationType": null,
     "subscriptionType": null,
     "types": [
+      {
+        "kind": "OBJECT",
+        "name": "Article",
+        "fields": [
+          {
+            "name": "bureaus",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Bureau",
+                  "ofType": null
+                }
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "content",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "createdAt",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Any"
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "id",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Any"
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "number",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Any"
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "publishedAt",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "title",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Any"
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "updatedAt",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Any"
+              }
+            },
+            "args": []
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ArticleConnection",
+        "fields": [
+          {
+            "name": "edges",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ArticleEdge",
+                "ofType": null
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "nodes",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Article",
+                "ofType": null
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "pageInfo",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "args": []
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ArticleEdge",
+        "fields": [
+          {
+            "name": "cursor",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Any"
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "node",
+            "type": {
+              "kind": "OBJECT",
+              "name": "Article",
+              "ofType": null
+            },
+            "args": []
+          }
+        ],
+        "interfaces": []
+      },
       {
         "kind": "OBJECT",
         "name": "Bureau",
@@ -185,8 +458,91 @@ export default {
       },
       {
         "kind": "OBJECT",
+        "name": "PageInfo",
+        "fields": [
+          {
+            "name": "endCursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "hasNextPage",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Any"
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "hasPreviousPage",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Any"
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "startCursor",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "OBJECT",
         "name": "Query",
         "fields": [
+          {
+            "name": "articles",
+            "type": {
+              "kind": "OBJECT",
+              "name": "ArticleConnection",
+              "ofType": null
+            },
+            "args": [
+              {
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              }
+            ]
+          },
           {
             "name": "bureau",
             "type": {

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -119,7 +119,7 @@ export type QueryBureauArgs = {
 
 export type ArticleListItemFragment = { __typename?: 'Article', id: string, title: string, publishedAt?: any | null, updatedAt: any, bureaus?: Array<{ __typename?: 'Bureau', name: string }> | null };
 
-export type ArticlesPageFragment = { __typename?: 'ArticleConnection', nodes?: Array<{ __typename?: 'Article', id: string, title: string, publishedAt?: any | null, updatedAt: any, bureaus?: Array<{ __typename?: 'Bureau', name: string }> | null } | null> | null, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean } };
+export type ArticlesPageFragment = { __typename?: 'ArticleConnection', nodes?: Array<{ __typename?: 'Article', id: string, title: string, publishedAt?: any | null, updatedAt: any, bureaus?: Array<{ __typename?: 'Bureau', name: string }> | null } | null> | null, pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasPreviousPage: boolean, hasNextPage: boolean } };
 
 export type GetArticlesPageQueryVariables = Exact<{
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -127,7 +127,7 @@ export type GetArticlesPageQueryVariables = Exact<{
 }>;
 
 
-export type GetArticlesPageQuery = { __typename?: 'Query', articles?: { __typename?: 'ArticleConnection', nodes?: Array<{ __typename?: 'Article', id: string, title: string, publishedAt?: any | null, updatedAt: any, bureaus?: Array<{ __typename?: 'Bureau', name: string }> | null } | null> | null, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean } } | null };
+export type GetArticlesPageQuery = { __typename?: 'Query', articles?: { __typename?: 'ArticleConnection', nodes?: Array<{ __typename?: 'Article', id: string, title: string, publishedAt?: any | null, updatedAt: any, bureaus?: Array<{ __typename?: 'Bureau', name: string }> | null } | null> | null, pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasPreviousPage: boolean, hasNextPage: boolean } } | null };
 
 export type GetBureausQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -158,7 +158,9 @@ export const ArticlesPageFragmentDoc = gql`
     ...ArticleListItem
   }
   pageInfo {
+    startCursor
     endCursor
+    hasPreviousPage
     hasNextPage
   }
 }

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -117,11 +117,11 @@ export type QueryBureauArgs = {
   slug: Scalars['String']['input'];
 };
 
-export type ArticlesPageFragment = { __typename?: 'ArticleConnection', pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean }, nodes?: Array<{ __typename?: 'Article', title: string } | null> | null };
-
 export type ArticleListFragment = { __typename?: 'ArticleConnection', nodes?: Array<{ __typename?: 'Article', title: string } | null> | null };
 
-export type ArticleListFieldFragment = { __typename?: 'Article', title: string };
+export type ArticleNodesFieldFragment = { __typename?: 'Article', title: string };
+
+export type ArticlesPageFragment = { __typename?: 'ArticleConnection', pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean }, nodes?: Array<{ __typename?: 'Article', title: string } | null> | null };
 
 export type GetArticlesPageQueryVariables = Exact<{
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -142,18 +142,18 @@ export type GetBureauQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type GetBureauQuery = { __typename?: 'Query', bureau?: { __typename?: 'Bureau', id: string } | null };
 
-export const ArticleListFieldFragmentDoc = gql`
-    fragment ArticleListField on Article {
+export const ArticleNodesFieldFragmentDoc = gql`
+    fragment ArticleNodesField on Article {
   title
 }
     `;
 export const ArticleListFragmentDoc = gql`
     fragment ArticleList on ArticleConnection {
   nodes {
-    ...ArticleListField
+    ...ArticleNodesField
   }
 }
-    ${ArticleListFieldFragmentDoc}`;
+    ${ArticleNodesFieldFragmentDoc}`;
 export const ArticlesPageFragmentDoc = gql`
     fragment ArticlesPage on ArticleConnection {
   ...ArticleList

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -124,6 +124,7 @@ export type ArticlesPageFragment = { __typename?: 'ArticleConnection', nodes?: A
 export type GetArticlesPageQueryVariables = Exact<{
   first?: InputMaybe<Scalars['Int']['input']>;
   endCursor?: InputMaybe<Scalars['String']['input']>;
+  startCursor?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
@@ -173,8 +174,8 @@ export const BureausFragmentDoc = gql`
 }
     `;
 export const GetArticlesPageDocument = gql`
-    query GetArticlesPage($first: Int = 10, $endCursor: String) {
-  articles(first: $first, after: $endCursor) {
+    query GetArticlesPage($first: Int = 10, $endCursor: String, $startCursor: String) {
+  articles(first: $first, after: $endCursor, before: $startCursor) {
     ...ArticlesPage
   }
 }

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -121,14 +121,14 @@ export type ArticleListFragment = { __typename?: 'ArticleConnection', nodes?: Ar
 
 export type ArticleNodesFieldFragment = { __typename?: 'Article', title: string };
 
-export type ArticlesPageFragment = { __typename?: 'ArticleConnection', pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean }, nodes?: Array<{ __typename?: 'Article', title: string } | null> | null };
+export type ArticlesPageFragment = { __typename?: 'ArticleConnection', nodes?: Array<{ __typename?: 'Article', title: string } | null> | null, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean } };
 
 export type GetArticlesPageQueryVariables = Exact<{
   first?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 
-export type GetArticlesPageQuery = { __typename?: 'Query', articles?: { __typename?: 'ArticleConnection', pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean }, nodes?: Array<{ __typename?: 'Article', title: string } | null> | null } | null };
+export type GetArticlesPageQuery = { __typename?: 'Query', articles?: { __typename?: 'ArticleConnection', nodes?: Array<{ __typename?: 'Article', title: string } | null> | null, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean } } | null };
 
 export type GetBureausQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -156,13 +156,17 @@ export const ArticleListFragmentDoc = gql`
     ${ArticleNodesFieldFragmentDoc}`;
 export const ArticlesPageFragmentDoc = gql`
     fragment ArticlesPage on ArticleConnection {
-  ...ArticleList
+  nodes {
+    ...ArticleNodesField
+  }
   pageInfo {
     endCursor
     hasNextPage
   }
+  ...ArticleList
 }
-    ${ArticleListFragmentDoc}`;
+    ${ArticleNodesFieldFragmentDoc}
+${ArticleListFragmentDoc}`;
 export const BureausFragmentDoc = gql`
     fragment bureaus on Bureau {
   id

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -174,7 +174,7 @@ export const BureausFragmentDoc = gql`
 }
     `;
 export const GetArticlesPageDocument = gql`
-    query GetArticlesPage($first: Int = 10, $endCursor: String, $startCursor: String) {
+    query GetArticlesPage($first: Int = 5, $endCursor: String, $startCursor: String) {
   articles(first: $first, after: $endCursor, before: $startCursor) {
     ...ArticlesPage
   }

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -117,9 +117,9 @@ export type QueryBureauArgs = {
   slug: Scalars['String']['input'];
 };
 
-export type ArticlesPageFragment = { __typename?: 'ArticleConnection', nodes?: Array<{ __typename?: 'Article', title: string, publishedAt?: any | null, updatedAt: any, bureaus?: Array<{ __typename?: 'Bureau', name: string }> | null } | null> | null, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean } };
+export type ArticleListItemFragment = { __typename?: 'Article', title: string, publishedAt?: any | null, updatedAt: any, bureaus?: Array<{ __typename?: 'Bureau', name: string }> | null };
 
-export type ArticleNodesFieldFragment = { __typename?: 'Article', title: string, publishedAt?: any | null, updatedAt: any, bureaus?: Array<{ __typename?: 'Bureau', name: string }> | null };
+export type ArticlesPageFragment = { __typename?: 'ArticleConnection', nodes?: Array<{ __typename?: 'Article', title: string, publishedAt?: any | null, updatedAt: any, bureaus?: Array<{ __typename?: 'Bureau', name: string }> | null } | null> | null, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean } };
 
 export type GetArticlesPageQueryVariables = Exact<{
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -140,8 +140,8 @@ export type GetBureauQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type GetBureauQuery = { __typename?: 'Query', bureau?: { __typename?: 'Bureau', id: string } | null };
 
-export const ArticleNodesFieldFragmentDoc = gql`
-    fragment ArticleNodesField on Article {
+export const ArticleListItemFragmentDoc = gql`
+    fragment ArticleListItem on Article {
   title
   bureaus {
     name
@@ -153,14 +153,14 @@ export const ArticleNodesFieldFragmentDoc = gql`
 export const ArticlesPageFragmentDoc = gql`
     fragment ArticlesPage on ArticleConnection {
   nodes {
-    ...ArticleNodesField
+    ...ArticleListItem
   }
   pageInfo {
     endCursor
     hasNextPage
   }
 }
-    ${ArticleNodesFieldFragmentDoc}`;
+    ${ArticleListItemFragmentDoc}`;
 export const BureausFragmentDoc = gql`
     fragment bureaus on Bureau {
   id

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -117,18 +117,16 @@ export type QueryBureauArgs = {
   slug: Scalars['String']['input'];
 };
 
-export type ArticleListFragment = { __typename?: 'ArticleConnection', nodes?: Array<{ __typename?: 'Article', title: string } | null> | null };
+export type ArticlesPageFragment = { __typename?: 'ArticleConnection', nodes?: Array<{ __typename?: 'Article', title: string, publishedAt?: any | null, updatedAt: any, bureaus?: Array<{ __typename?: 'Bureau', name: string }> | null } | null> | null, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean } };
 
-export type ArticleNodesFieldFragment = { __typename?: 'Article', title: string };
-
-export type ArticlesPageFragment = { __typename?: 'ArticleConnection', nodes?: Array<{ __typename?: 'Article', title: string } | null> | null, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean } };
+export type ArticleNodesFieldFragment = { __typename?: 'Article', title: string, publishedAt?: any | null, updatedAt: any, bureaus?: Array<{ __typename?: 'Bureau', name: string }> | null };
 
 export type GetArticlesPageQueryVariables = Exact<{
   first?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 
-export type GetArticlesPageQuery = { __typename?: 'Query', articles?: { __typename?: 'ArticleConnection', nodes?: Array<{ __typename?: 'Article', title: string } | null> | null, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean } } | null };
+export type GetArticlesPageQuery = { __typename?: 'Query', articles?: { __typename?: 'ArticleConnection', nodes?: Array<{ __typename?: 'Article', title: string, publishedAt?: any | null, updatedAt: any, bureaus?: Array<{ __typename?: 'Bureau', name: string }> | null } | null> | null, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean } } | null };
 
 export type GetBureausQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -145,15 +143,13 @@ export type GetBureauQuery = { __typename?: 'Query', bureau?: { __typename?: 'Bu
 export const ArticleNodesFieldFragmentDoc = gql`
     fragment ArticleNodesField on Article {
   title
+  bureaus {
+    name
+  }
+  publishedAt
+  updatedAt
 }
     `;
-export const ArticleListFragmentDoc = gql`
-    fragment ArticleList on ArticleConnection {
-  nodes {
-    ...ArticleNodesField
-  }
-}
-    ${ArticleNodesFieldFragmentDoc}`;
 export const ArticlesPageFragmentDoc = gql`
     fragment ArticlesPage on ArticleConnection {
   nodes {
@@ -163,10 +159,8 @@ export const ArticlesPageFragmentDoc = gql`
     endCursor
     hasNextPage
   }
-  ...ArticleList
 }
-    ${ArticleNodesFieldFragmentDoc}
-${ArticleListFragmentDoc}`;
+    ${ArticleNodesFieldFragmentDoc}`;
 export const BureausFragmentDoc = gql`
     fragment bureaus on Bureau {
   id

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -117,9 +117,9 @@ export type QueryBureauArgs = {
   slug: Scalars['String']['input'];
 };
 
-export type ArticleListItemFragment = { __typename?: 'Article', id: string, title: string, publishedAt?: any | null, updatedAt: any, bureaus?: Array<{ __typename?: 'Bureau', name: string }> | null };
+export type ArticleListItemFragment = { __typename?: 'Article', id: string, title: string, publishedAt?: any | null, updatedAt: any, bureaus?: Array<{ __typename?: 'Bureau', name: string, slug: string }> | null };
 
-export type ArticlesPageFragment = { __typename?: 'ArticleConnection', nodes?: Array<{ __typename?: 'Article', id: string, title: string, publishedAt?: any | null, updatedAt: any, bureaus?: Array<{ __typename?: 'Bureau', name: string }> | null } | null> | null, pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasPreviousPage: boolean, hasNextPage: boolean } };
+export type ArticlesPageFragment = { __typename?: 'ArticleConnection', nodes?: Array<{ __typename?: 'Article', id: string, title: string, publishedAt?: any | null, updatedAt: any, bureaus?: Array<{ __typename?: 'Bureau', name: string, slug: string }> | null } | null> | null, pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasPreviousPage: boolean, hasNextPage: boolean } };
 
 export type GetArticlesPageQueryVariables = Exact<{
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -129,7 +129,7 @@ export type GetArticlesPageQueryVariables = Exact<{
 }>;
 
 
-export type GetArticlesPageQuery = { __typename?: 'Query', articles?: { __typename?: 'ArticleConnection', nodes?: Array<{ __typename?: 'Article', id: string, title: string, publishedAt?: any | null, updatedAt: any, bureaus?: Array<{ __typename?: 'Bureau', name: string }> | null } | null> | null, pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasPreviousPage: boolean, hasNextPage: boolean } } | null };
+export type GetArticlesPageQuery = { __typename?: 'Query', articles?: { __typename?: 'ArticleConnection', nodes?: Array<{ __typename?: 'Article', id: string, title: string, publishedAt?: any | null, updatedAt: any, bureaus?: Array<{ __typename?: 'Bureau', name: string, slug: string }> | null } | null> | null, pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasPreviousPage: boolean, hasNextPage: boolean } } | null };
 
 export type GetBureausQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -149,6 +149,7 @@ export const ArticleListItemFragmentDoc = gql`
   title
   bureaus {
     name
+    slug
   }
   publishedAt
   updatedAt

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -117,9 +117,9 @@ export type QueryBureauArgs = {
   slug: Scalars['String']['input'];
 };
 
-export type ArticleListItemFragment = { __typename?: 'Article', title: string, publishedAt?: any | null, updatedAt: any, bureaus?: Array<{ __typename?: 'Bureau', name: string }> | null };
+export type ArticleListItemFragment = { __typename?: 'Article', id: string, title: string, publishedAt?: any | null, updatedAt: any, bureaus?: Array<{ __typename?: 'Bureau', name: string }> | null };
 
-export type ArticlesPageFragment = { __typename?: 'ArticleConnection', nodes?: Array<{ __typename?: 'Article', title: string, publishedAt?: any | null, updatedAt: any, bureaus?: Array<{ __typename?: 'Bureau', name: string }> | null } | null> | null, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean } };
+export type ArticlesPageFragment = { __typename?: 'ArticleConnection', nodes?: Array<{ __typename?: 'Article', id: string, title: string, publishedAt?: any | null, updatedAt: any, bureaus?: Array<{ __typename?: 'Bureau', name: string }> | null } | null> | null, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean } };
 
 export type GetArticlesPageQueryVariables = Exact<{
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -127,7 +127,7 @@ export type GetArticlesPageQueryVariables = Exact<{
 }>;
 
 
-export type GetArticlesPageQuery = { __typename?: 'Query', articles?: { __typename?: 'ArticleConnection', nodes?: Array<{ __typename?: 'Article', title: string, publishedAt?: any | null, updatedAt: any, bureaus?: Array<{ __typename?: 'Bureau', name: string }> | null } | null> | null, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean } } | null };
+export type GetArticlesPageQuery = { __typename?: 'Query', articles?: { __typename?: 'ArticleConnection', nodes?: Array<{ __typename?: 'Article', id: string, title: string, publishedAt?: any | null, updatedAt: any, bureaus?: Array<{ __typename?: 'Bureau', name: string }> | null } | null> | null, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean } } | null };
 
 export type GetBureausQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -143,6 +143,7 @@ export type GetBureauQuery = { __typename?: 'Query', bureau?: { __typename?: 'Bu
 
 export const ArticleListItemFragmentDoc = gql`
     fragment ArticleListItem on Article {
+  id
   title
   bureaus {
     name

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -123,12 +123,12 @@ export type ArticleListFragment = { __typename?: 'ArticleConnection', nodes?: Ar
 
 export type ArticleListFieldFragment = { __typename?: 'Article', title: string };
 
-export type GetArticlesQueryVariables = Exact<{
+export type GetArticlesPageQueryVariables = Exact<{
   first?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 
-export type GetArticlesQuery = { __typename?: 'Query', articles?: { __typename?: 'ArticleConnection', pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean }, nodes?: Array<{ __typename?: 'Article', title: string } | null> | null } | null };
+export type GetArticlesPageQuery = { __typename?: 'Query', articles?: { __typename?: 'ArticleConnection', pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean }, nodes?: Array<{ __typename?: 'Article', title: string } | null> | null } | null };
 
 export type GetBureausQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -170,16 +170,16 @@ export const BureausFragmentDoc = gql`
   description
 }
     `;
-export const GetArticlesDocument = gql`
-    query GetArticles($first: Int = 10) {
+export const GetArticlesPageDocument = gql`
+    query GetArticlesPage($first: Int = 10) {
   articles(first: $first) {
     ...ArticlesPage
   }
 }
     ${ArticlesPageFragmentDoc}`;
 
-export function useGetArticlesQuery(options?: Omit<Urql.UseQueryArgs<GetArticlesQueryVariables>, 'query'>) {
-  return Urql.useQuery<GetArticlesQuery, GetArticlesQueryVariables>({ query: GetArticlesDocument, ...options });
+export function useGetArticlesPageQuery(options?: Omit<Urql.UseQueryArgs<GetArticlesPageQueryVariables>, 'query'>) {
+  return Urql.useQuery<GetArticlesPageQuery, GetArticlesPageQueryVariables>({ query: GetArticlesPageDocument, ...options });
 };
 export const GetBureausDocument = gql`
     query GetBureaus {

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -123,6 +123,7 @@ export type ArticlesPageFragment = { __typename?: 'ArticleConnection', nodes?: A
 
 export type GetArticlesPageQueryVariables = Exact<{
   first?: InputMaybe<Scalars['Int']['input']>;
+  endCursor?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
@@ -169,8 +170,8 @@ export const BureausFragmentDoc = gql`
 }
     `;
 export const GetArticlesPageDocument = gql`
-    query GetArticlesPage($first: Int = 10) {
-  articles(first: $first) {
+    query GetArticlesPage($first: Int = 10, $endCursor: String) {
+  articles(first: $first, after: $endCursor) {
     ...ArticlesPage
   }
 }

--- a/src/pages/articles/index.gql
+++ b/src/pages/articles/index.gql
@@ -1,0 +1,5 @@
+query GetArticles($first: Int = 10) {
+  articles(first: $first) {
+    ...ArticlesPage
+  }
+}

--- a/src/pages/articles/index.gql
+++ b/src/pages/articles/index.gql
@@ -1,9 +1,15 @@
 query GetArticlesPage(
-  $first: Int = 5
+  $first: Int
+  $last: Int
   $endCursor: String
   $startCursor: String
 ) {
-  articles(first: $first, after: $endCursor, before: $startCursor) {
+  articles(
+    first: $first
+    last: $last
+    after: $endCursor
+    before: $startCursor
+  ) {
     ...ArticlesPage
   }
 }

--- a/src/pages/articles/index.gql
+++ b/src/pages/articles/index.gql
@@ -1,5 +1,5 @@
 query GetArticlesPage(
-  $first: Int = 10
+  $first: Int = 5
   $endCursor: String
   $startCursor: String
 ) {

--- a/src/pages/articles/index.gql
+++ b/src/pages/articles/index.gql
@@ -1,4 +1,4 @@
-query GetArticles($first: Int = 10) {
+query GetArticlesPage($first: Int = 10) {
   articles(first: $first) {
     ...ArticlesPage
   }

--- a/src/pages/articles/index.gql
+++ b/src/pages/articles/index.gql
@@ -1,5 +1,5 @@
-query GetArticlesPage($first: Int = 10) {
-  articles(first: $first) {
+query GetArticlesPage($first: Int = 10, $endCursor: String) {
+  articles(first: $first, after: $endCursor) {
     ...ArticlesPage
   }
 }

--- a/src/pages/articles/index.gql
+++ b/src/pages/articles/index.gql
@@ -1,5 +1,9 @@
-query GetArticlesPage($first: Int = 10, $endCursor: String) {
-  articles(first: $first, after: $endCursor) {
+query GetArticlesPage(
+  $first: Int = 10
+  $endCursor: String
+  $startCursor: String
+) {
+  articles(first: $first, after: $endCursor, before: $startCursor) {
     ...ArticlesPage
   }
 }

--- a/src/pages/articles/index.tsx
+++ b/src/pages/articles/index.tsx
@@ -1,6 +1,6 @@
 import {
   ArticlesPageComponent,
-  PAGINATE_ARTICLES_PER,
+  ARTICLES_PER_PAGE,
 } from "@/components/pages/articles"
 import { ssrClient } from "@/constants/urql"
 import {
@@ -18,7 +18,7 @@ interface Props {}
 const ArticlesPage = () => {
   const [articles] = useGetArticlesPageQuery({
     variables: {
-      first: PAGINATE_ARTICLES_PER,
+      first: ARTICLES_PER_PAGE,
     },
   })
   useHydrateAtoms([
@@ -34,7 +34,7 @@ export const getServerSideProps = (async (context) => {
   try {
     await Promise.all([
       client
-        .query(GetArticlesPageDocument, { first: PAGINATE_ARTICLES_PER })
+        .query(GetArticlesPageDocument, { first: ARTICLES_PER_PAGE })
         .toPromise(),
     ])
   } catch (e) {

--- a/src/pages/articles/index.tsx
+++ b/src/pages/articles/index.tsx
@@ -1,34 +1,34 @@
 import { ArticlesPageComponent } from "@/components/pages/articles"
 import { ssrClient } from "@/constants/urql"
+import {
+  GetArticlesPageDocument,
+  useGetArticlesPageQuery,
+} from "@/graphql/generated"
+import { articlesPageAtom, emptyArticlesPage } from "@/store/article"
+import { useHydrateAtoms } from "jotai/utils"
 import { GetServerSideProps } from "next"
-import { initUrqlClient, withUrqlClient } from "next-urql"
-import { cacheExchange, fetchExchange, ssrExchange } from "urql"
+import { withUrqlClient } from "next-urql"
+import { cacheExchange, fetchExchange } from "urql"
 
 interface Props {}
 
 const ArticlesPage = () => {
-  // const [bureaus] = useGetBureausQuery()
-  // useHydrateAtoms([[bureausAtom, bureaus.data?.bureaus || emptyBureaus]])
+  const [articles] = useGetArticlesPageQuery()
+  useHydrateAtoms([
+    [articlesPageAtom, articles.data?.articles || emptyArticlesPage],
+  ])
 
   return <ArticlesPageComponent />
 }
 
 export const getServerSideProps = (async (context) => {
   const { ssrCache, client } = ssrClient()
-  // const ssrCache = ssrExchange({ isClient: false })
-  // const client = initUrqlClient(
-  //   {
-  //     url: `${process.env.NEXT_PUBLIC_WWWSITE_CONTAINER_ROOT}graphql`,
-  //     exchanges: [cacheExchange, ssrCache, fetchExchange],
-  //   },
-  //   false
-  // )
 
-  // try {
-  //   await Promise.all([client.query(GetBureausDocument, {}).toPromise()])
-  // } catch (e) {
-  //   console.log(e)
-  // }
+  try {
+    await Promise.all([client.query(GetArticlesPageDocument, {}).toPromise()])
+  } catch (e) {
+    console.log(e)
+  }
 
   if (!ssrCache.extractData()) {
     return {

--- a/src/pages/articles/index.tsx
+++ b/src/pages/articles/index.tsx
@@ -1,0 +1,50 @@
+import { ArticlesPageComponent } from "@/components/pages/articles"
+import { GetServerSideProps } from "next"
+import { initUrqlClient, withUrqlClient } from "next-urql"
+import { cacheExchange, fetchExchange, ssrExchange } from "urql"
+
+interface Props {}
+
+const ArticlesPage = () => {
+  // const [bureaus] = useGetBureausQuery()
+  // useHydrateAtoms([[bureausAtom, bureaus.data?.bureaus || emptyBureaus]])
+
+  return <ArticlesPageComponent />
+}
+
+export const getServerSideProps = (async (context) => {
+  const ssrCache = ssrExchange({ isClient: false })
+  const client = initUrqlClient(
+    {
+      url: `${process.env.NEXT_PUBLIC_WWWSITE_CONTAINER_ROOT}graphql`,
+      exchanges: [cacheExchange, ssrCache, fetchExchange],
+    },
+    false
+  )
+
+  // try {
+  //   await Promise.all([client.query(GetBureausDocument, {}).toPromise()])
+  // } catch (e) {
+  //   console.log(e)
+  // }
+
+  if (!ssrCache.extractData()) {
+    return {
+      notFound: true,
+    }
+  }
+
+  return {
+    props: {
+      urqlState: ssrCache.extractData(),
+    },
+  }
+}) satisfies GetServerSideProps<Props>
+
+export default withUrqlClient(
+  (ssrExchange) => ({
+    url: `${process.env.NEXT_PUBLIC_WWWSITE_CONTAINER_ROOT}graphql`,
+    exchanges: [cacheExchange, ssrExchange, fetchExchange],
+  }),
+  { ssr: false }
+)(ArticlesPage)

--- a/src/pages/articles/index.tsx
+++ b/src/pages/articles/index.tsx
@@ -1,4 +1,5 @@
 import { ArticlesPageComponent } from "@/components/pages/articles"
+import { ssrClient } from "@/constants/urql"
 import { GetServerSideProps } from "next"
 import { initUrqlClient, withUrqlClient } from "next-urql"
 import { cacheExchange, fetchExchange, ssrExchange } from "urql"
@@ -13,14 +14,15 @@ const ArticlesPage = () => {
 }
 
 export const getServerSideProps = (async (context) => {
-  const ssrCache = ssrExchange({ isClient: false })
-  const client = initUrqlClient(
-    {
-      url: `${process.env.NEXT_PUBLIC_WWWSITE_CONTAINER_ROOT}graphql`,
-      exchanges: [cacheExchange, ssrCache, fetchExchange],
-    },
-    false
-  )
+  const { ssrCache, client } = ssrClient()
+  // const ssrCache = ssrExchange({ isClient: false })
+  // const client = initUrqlClient(
+  //   {
+  //     url: `${process.env.NEXT_PUBLIC_WWWSITE_CONTAINER_ROOT}graphql`,
+  //     exchanges: [cacheExchange, ssrCache, fetchExchange],
+  //   },
+  //   false
+  // )
 
   // try {
   //   await Promise.all([client.query(GetBureausDocument, {}).toPromise()])

--- a/src/pages/articles/index.tsx
+++ b/src/pages/articles/index.tsx
@@ -1,4 +1,7 @@
-import { ArticlesPageComponent } from "@/components/pages/articles"
+import {
+  ArticlesPageComponent,
+  PAGINATE_ARTICLES_PER,
+} from "@/components/pages/articles"
 import { ssrClient } from "@/constants/urql"
 import {
   GetArticlesPageDocument,
@@ -13,7 +16,11 @@ import { cacheExchange, fetchExchange } from "urql"
 interface Props {}
 
 const ArticlesPage = () => {
-  const [articles] = useGetArticlesPageQuery()
+  const [articles] = useGetArticlesPageQuery({
+    variables: {
+      first: PAGINATE_ARTICLES_PER,
+    },
+  })
   useHydrateAtoms([
     [articlesPageAtom, articles.data?.articles || emptyArticlesPage],
   ])
@@ -25,7 +32,11 @@ export const getServerSideProps = (async (context) => {
   const { ssrCache, client } = ssrClient()
 
   try {
-    await Promise.all([client.query(GetArticlesPageDocument, {}).toPromise()])
+    await Promise.all([
+      client
+        .query(GetArticlesPageDocument, { first: PAGINATE_ARTICLES_PER })
+        .toPromise(),
+    ])
   } catch (e) {
     console.log(e)
   }

--- a/src/pages/bureaus/index.tsx
+++ b/src/pages/bureaus/index.tsx
@@ -1,4 +1,5 @@
 import { BureausPageComponent } from "@/components/pages/bureaus"
+import { ssrClient } from "@/constants/urql"
 import { GetBureausDocument, useGetBureausQuery } from "@/graphql/generated"
 import { bureausAtom, emptyBureaus } from "@/store/bureaus"
 import { useHydrateAtoms } from "jotai/utils"
@@ -16,14 +17,7 @@ const BureausPage = () => {
 }
 
 export const getServerSideProps = (async (context) => {
-  const ssrCache = ssrExchange({ isClient: false })
-  const client = initUrqlClient(
-    {
-      url: `${process.env.NEXT_PUBLIC_WWWSITE_CONTAINER_ROOT}graphql`,
-      exchanges: [cacheExchange, ssrCache, fetchExchange],
-    },
-    false
-  )
+  const { ssrCache, client } = ssrClient()
 
   try {
     await Promise.all([client.query(GetBureausDocument, {}).toPromise()])

--- a/src/store/article.ts
+++ b/src/store/article.ts
@@ -1,0 +1,10 @@
+import { ArticlesPageFragment } from "@/graphql/generated"
+import { atom } from "jotai"
+
+export const emptyArticlesPage: ArticlesPageFragment = {
+  pageInfo: {
+    hasNextPage: false,
+  },
+}
+
+export const articlesPageAtom = atom<ArticlesPageFragment>(emptyArticlesPage)

--- a/src/store/article.ts
+++ b/src/store/article.ts
@@ -3,6 +3,7 @@ import { atom } from "jotai"
 
 export const emptyArticlesPage: ArticlesPageFragment = {
   pageInfo: {
+    hasPreviousPage: false,
     hasNextPage: false,
   },
 }


### PR DESCRIPTION
**プルリクエスト提出前確認項目**
- [x] closeする各Issueの受け入れ条件をすべて満たしている
- [x] 実装ページや機能があればそれをWikiに掲載した
# Issue
- close #1 
## Epic
- 
## 目的
記事一覧ページにページネーションと影をつけ、表示を見やすくする
## 実装詳細
- src/components/ArticleListItem/index.tsx
  - 記事一覧の中の一つの記事
- src/components/ViewA/index.tsx
- src/components/ViewButton/index.tsx
  - aタグとbuttonタグを今後のために共通化
  - aタグを別タブで開くときのセキュリティ対策を忘れないように対応
- src/components/pages/articles/index.tsx
  - 記事リストを作成する
  - ほかのところで記事リストが必要になったときに要素として切り出しても良い
  - 次へボタン、前へボタンは違う関数とクエリを呼び出し、state: articlesに格納する
- src/constants/urql.ts
  - SSRのクライアント処理は共通化できそうだったので定数化
## 動作
- [x] 記事一覧が10件毎に表示される
- [x] 記事一覧の次へボタン、前へボタンが機能する

## レビュー観点

## デプロイ種別
### 種別（選択）
マイナーリリース
### 追加作業／確認項目
- Snak0201/fpb-wwwsite#158 と同時にリリースする
## メモ
