### PR TITLE
push時にビルドのテストを追加する

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  test-build:
+  test-docker:
     runs-on: ubuntu-latest
     timeout-minutes: 300
     
@@ -22,3 +22,21 @@ jobs:
           docker pull "$CACHE_TAG" || true
 
           docker build .
+          
+  test-yarn:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        
+      - name: Setup Node 20
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20.x'
+      
+      - name: yarn install
+        run: yarn
+
+      - name: yarn build
+        run: yarn build

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -1,0 +1,24 @@
+name: CI-Check
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 300
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Check build
+        run: |
+          docker pull "$CACHE_TAG" || true
+
+          docker build .


### PR DESCRIPTION
**プルリクエスト提出前確認項目**
- [x] closeする各Issueの受け入れ条件をすべて満たしている
- [x] 実装ページや機能があればそれをWikiに掲載した
# Issue
- close #13 
## Epic
- 
## 目的
デプロイ後にビルドできないというエラーを防ぎ、手動のテストで気づきにくいバグに気づける可能性が上がる
## 実装詳細
- ci-checkを追加する
  - docker buildができることと、yarn buildができることを両方検証する
## 動作
- [x] CIが全てGREENである
- [x] プッシュ時にビルドをテストするCIが追加されている

## レビュー観点

## デプロイ種別
### 種別（選択）
不要
### 追加作業／確認項目
- 
## メモ
