### PR TITLE
#10 記事一覧ページに委員会の表示を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,7 @@
 3. `fpb-wwwsite`を起動します
 4. `docker compose up -d`で起動します
 5. `localhost:8001`で画面が開きます
+
+## リリース手順
+
+1. サーバー内の該当フォルダで`yarn release`コマンドを実行する

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "generate": "graphql-codegen --config codegen.yml"
+    "generate": "graphql-codegen --config codegen.yml",
+    "prod-update-branch": "git fetch && git pull",
+    "prod-restart": "pm2 restart wwwview",
+    "release": "yarn prod-update-branch && yarn && yarn build && yarn prod-restart"
   },
   "dependencies": {
     "@urql/next": "^1.1.1",

--- a/src/components/ArticleListItem/fragment.gql
+++ b/src/components/ArticleListItem/fragment.gql
@@ -5,6 +5,10 @@ fragment ArticleListItem on Article {
     name
     slug
   }
+  committees {
+    name
+    slug
+  }
   publishedAt
   updatedAt
 }

--- a/src/components/ArticleListItem/index.tsx
+++ b/src/components/ArticleListItem/index.tsx
@@ -40,6 +40,22 @@ export const ArticleListItem = ({ article }: Props) => {
         </div>
       )}
 
+      {!!article.committees?.length && (
+        <div>
+          <span className={styles.description}>管轄委員会:</span>
+          {article.committees.map((committee, index) => (
+            <ViewA
+              key={index}
+              href={`committees/${committee.slug}`}
+              className={styles.committee}
+              opensInNewTab={true}
+            >
+              {committee.name}
+            </ViewA>
+          ))}
+        </div>
+      )}
+
       {!!publishedAt && (
         <div>
           <span className={styles.description}>公開日時:</span>

--- a/src/components/ArticleListItem/style.css.ts
+++ b/src/components/ArticleListItem/style.css.ts
@@ -18,4 +18,5 @@ export const styles = {
   }),
   description: style({ marginRight: "5px" }),
   bureau: style({ textDecoration: "none", marginRight: "5px" }),
+  committee: style({ textDecoration: "none", marginRight: "5px" }),
 }

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -21,8 +21,10 @@ export type Scalars = {
 /** published article on Hoshinonaka Government */
 export type Article = {
   __typename?: 'Article';
-  /** jurisdiction bureau */
+  /** jurisdiction bureaus */
   bureaus?: Maybe<Array<Bureau>>;
+  /** jurisdiction committees */
+  committees?: Maybe<Array<Committee>>;
   /** markdown content */
   content?: Maybe<Scalars['String']['output']>;
   /** created at */
@@ -78,6 +80,40 @@ export type Bureau = {
   updatedAt: Scalars['ISO8601DateTime']['output'];
 };
 
+/** article tags */
+export type Committee = {
+  __typename?: 'Committee';
+  /** committee articles list */
+  articles?: Maybe<ArticleConnection>;
+  /** jurisdiction bureau */
+  bureau?: Maybe<Bureau>;
+  /** markdown content */
+  content?: Maybe<Scalars['String']['output']>;
+  /** created_at */
+  createdAt: Scalars['ISO8601DateTime']['output'];
+  /** short description */
+  description: Scalars['String']['output'];
+  /** id */
+  id: Scalars['ID']['output'];
+  /** name */
+  name: Scalars['String']['output'];
+  /** search keyword */
+  slug: Scalars['String']['output'];
+  /** is special committee */
+  special: Scalars['Boolean']['output'];
+  /** updated_at */
+  updatedAt: Scalars['ISO8601DateTime']['output'];
+};
+
+
+/** article tags */
+export type CommitteeArticlesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
 /** Information about pagination in a connection. */
 export type PageInfo = {
   __typename?: 'PageInfo';
@@ -100,6 +136,10 @@ export type Query = {
   bureau?: Maybe<Bureau>;
   /** all bureaus */
   bureaus?: Maybe<Array<Bureau>>;
+  /** committee detail */
+  committee?: Maybe<Committee>;
+  /** all committees list */
+  committees?: Maybe<Array<Committee>>;
 };
 
 
@@ -117,9 +157,15 @@ export type QueryBureauArgs = {
   slug: Scalars['String']['input'];
 };
 
-export type ArticleListItemFragment = { __typename?: 'Article', id: string, title: string, publishedAt?: any | null, updatedAt: any, bureaus?: Array<{ __typename?: 'Bureau', name: string, slug: string }> | null };
 
-export type ArticlesPageFragment = { __typename?: 'ArticleConnection', nodes?: Array<{ __typename?: 'Article', id: string, title: string, publishedAt?: any | null, updatedAt: any, bureaus?: Array<{ __typename?: 'Bureau', name: string, slug: string }> | null } | null> | null, pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasPreviousPage: boolean, hasNextPage: boolean } };
+/** queries */
+export type QueryCommitteeArgs = {
+  slug: Scalars['String']['input'];
+};
+
+export type ArticleListItemFragment = { __typename?: 'Article', id: string, title: string, publishedAt?: any | null, updatedAt: any, bureaus?: Array<{ __typename?: 'Bureau', name: string, slug: string }> | null, committees?: Array<{ __typename?: 'Committee', name: string, slug: string }> | null };
+
+export type ArticlesPageFragment = { __typename?: 'ArticleConnection', nodes?: Array<{ __typename?: 'Article', id: string, title: string, publishedAt?: any | null, updatedAt: any, bureaus?: Array<{ __typename?: 'Bureau', name: string, slug: string }> | null, committees?: Array<{ __typename?: 'Committee', name: string, slug: string }> | null } | null> | null, pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasPreviousPage: boolean, hasNextPage: boolean } };
 
 export type GetArticlesPageQueryVariables = Exact<{
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -129,7 +175,7 @@ export type GetArticlesPageQueryVariables = Exact<{
 }>;
 
 
-export type GetArticlesPageQuery = { __typename?: 'Query', articles?: { __typename?: 'ArticleConnection', nodes?: Array<{ __typename?: 'Article', id: string, title: string, publishedAt?: any | null, updatedAt: any, bureaus?: Array<{ __typename?: 'Bureau', name: string, slug: string }> | null } | null> | null, pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasPreviousPage: boolean, hasNextPage: boolean } } | null };
+export type GetArticlesPageQuery = { __typename?: 'Query', articles?: { __typename?: 'ArticleConnection', nodes?: Array<{ __typename?: 'Article', id: string, title: string, publishedAt?: any | null, updatedAt: any, bureaus?: Array<{ __typename?: 'Bureau', name: string, slug: string }> | null, committees?: Array<{ __typename?: 'Committee', name: string, slug: string }> | null } | null> | null, pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasPreviousPage: boolean, hasNextPage: boolean } } | null };
 
 export type GetBureausQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -148,6 +194,10 @@ export const ArticleListItemFragmentDoc = gql`
   id
   title
   bureaus {
+    name
+    slug
+  }
+  committees {
     name
     slug
   }
@@ -230,6 +280,21 @@ export default {
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "Bureau",
+                  "ofType": null
+                }
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "committees",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Committee",
                   "ofType": null
                 }
               }
@@ -463,6 +528,145 @@ export default {
       },
       {
         "kind": "OBJECT",
+        "name": "Committee",
+        "fields": [
+          {
+            "name": "articles",
+            "type": {
+              "kind": "OBJECT",
+              "name": "ArticleConnection",
+              "ofType": null
+            },
+            "args": [
+              {
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              }
+            ]
+          },
+          {
+            "name": "bureau",
+            "type": {
+              "kind": "OBJECT",
+              "name": "Bureau",
+              "ofType": null
+            },
+            "args": []
+          },
+          {
+            "name": "content",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Any"
+            },
+            "args": []
+          },
+          {
+            "name": "createdAt",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Any"
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "description",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Any"
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "id",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Any"
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "name",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Any"
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "slug",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Any"
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "special",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Any"
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "updatedAt",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Any"
+              }
+            },
+            "args": []
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "OBJECT",
         "name": "PageInfo",
         "fields": [
           {
@@ -577,6 +781,41 @@ export default {
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "Bureau",
+                  "ofType": null
+                }
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "committee",
+            "type": {
+              "kind": "OBJECT",
+              "name": "Committee",
+              "ofType": null
+            },
+            "args": [
+              {
+                "name": "slug",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "name": "committees",
+            "type": {
+              "kind": "LIST",
+              "ofType": {
+                "kind": "NON_NULL",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Committee",
                   "ofType": null
                 }
               }


### PR DESCRIPTION
**プルリクエスト提出前確認項目**
- [x] closeする各Issueの受け入れ条件をすべて満たしている
- [x] 実装ページや機能があればそれをWikiに掲載した
# Issue
- close #10
- close #25
## Epic
- #15
## 目的
記事一覧ページで各記事の委員会を把握することができるようにする
## 実装詳細
- 記事一覧でGQLから委員会を取得し、表示する
- リリース用のスクリプトを追加する
## 動作
- [x] 記事一覧で各記事の委員会を確認できる

## レビュー観点

## デプロイ種別
### 種別（選択）
- パッチリリース
### 追加作業／確認項目
- 
## メモ
